### PR TITLE
Optimize forward simulation: 6x speedup

### DIFF
--- a/Examples/Example2.ManyGrains/compare_outputs.py
+++ b/Examples/Example2.ManyGrains/compare_outputs.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""
+Compare C++ and Python IceNine detector image outputs for Example2.ManyGrains.
+
+Generates statistical comparison and identifies discrepancies.
+
+Usage:
+    cd Examples/Example2.ManyGrains
+    uv run python compare_outputs.py
+"""
+
+import sys
+from pathlib import Path
+import numpy as np
+import torch
+
+# Add icenine_py to Python path
+REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "icenine_py"))
+
+from icenine.image_data import ImageData
+
+
+def load_detector_image(filepath: Path) -> torch.Tensor:
+    """Load detector image from ASCII file."""
+    try:
+        img = ImageData(num_rows=2048, num_cols=2048, mode='dense')
+        img.load_ascii(str(filepath))
+        return img._pixels_dense
+    except Exception as e:
+        print(f"  Error loading {filepath.name}: {e}")
+        return None
+
+
+def compare_images(cpp_data: torch.Tensor, py_data: torch.Tensor, filename: str) -> dict:
+    """Compare two detector images and return metrics."""
+
+    abs_diff = torch.abs(cpp_data - py_data)
+
+    cpp_nonzero = (cpp_data > 0).sum().item()
+    py_nonzero = (py_data > 0).sum().item()
+
+    # Pixel overlap analysis
+    cpp_mask = cpp_data > 0
+    py_mask = py_data > 0
+    both_nonzero = (cpp_mask & py_mask).sum().item()
+    cpp_only = (cpp_mask & ~py_mask).sum().item()
+    py_only = (~cpp_mask & py_mask).sum().item()
+
+    # Relative diff only where both are nonzero
+    if both_nonzero > 0:
+        overlap_mask = cpp_mask & py_mask
+        rel_diff_at_overlap = (abs_diff[overlap_mask] / (torch.abs(cpp_data[overlap_mask]) + 1e-10))
+        max_rel_diff = rel_diff_at_overlap.max().item()
+        mean_rel_diff = rel_diff_at_overlap.mean().item()
+    else:
+        max_rel_diff = 0.0
+        mean_rel_diff = 0.0
+
+    metrics = {
+        'filename': filename,
+        'max_abs_diff': abs_diff.max().item(),
+        'mean_abs_diff': abs_diff.mean().item(),
+        'max_rel_diff': max_rel_diff,
+        'mean_rel_diff': mean_rel_diff,
+        'cpp_max': cpp_data.max().item(),
+        'py_max': py_data.max().item(),
+        'cpp_sum': cpp_data.sum().item(),
+        'py_sum': py_data.sum().item(),
+        'cpp_nonzero': cpp_nonzero,
+        'py_nonzero': py_nonzero,
+        'both_nonzero': both_nonzero,
+        'cpp_only': cpp_only,
+        'py_only': py_only,
+    }
+
+    # Correlation (only if both have non-zero pixels)
+    if cpp_nonzero > 0 and py_nonzero > 0:
+        cpp_flat = cpp_data.flatten()
+        py_flat = py_data.flatten()
+        correlation = torch.corrcoef(torch.stack([cpp_flat, py_flat]))[0, 1].item()
+        metrics['correlation'] = correlation
+    else:
+        metrics['correlation'] = float('nan') if (cpp_nonzero == 0 and py_nonzero == 0) else 0.0
+
+    return metrics
+
+
+def main():
+    """Run comparison between C++ and Python outputs."""
+
+    example_dir = Path(__file__).parent
+    cpp_dir = example_dir / "ScatteringData"
+    python_dir = example_dir / "ScatteringData_Python"
+
+    print("=" * 80)
+    print("IceNine C++ vs Python Output Comparison - Example2.ManyGrains")
+    print("=" * 80)
+    print(f"\nC++ output: {cpp_dir}")
+    print(f"Python output: {python_dir}\n")
+
+    if not cpp_dir.exists():
+        print(f"Error: C++ output directory not found: {cpp_dir}")
+        return 1
+
+    if not python_dir.exists():
+        print(f"Error: Python output directory not found: {python_dir}")
+        print("  Run run_python_simulation.py first!")
+        return 1
+
+    # Get file lists
+    cpp_files = sorted(cpp_dir.glob("*.d*"))
+    python_files = sorted(python_dir.glob("*.d*"))
+
+    print(f"Found {len(cpp_files)} C++ output files")
+    print(f"Found {len(python_files)} Python output files\n")
+
+    if len(cpp_files) == 0:
+        print("No C++ files found!")
+        return 1
+
+    if len(python_files) == 0:
+        print("No Python files found!")
+        return 1
+
+    # Compare each file
+    print("Comparing detector images...")
+    print("-" * 80)
+
+    results = []
+    missing_python = []
+    files_with_diffs = []
+    empty_both = 0
+    progress_interval = max(1, len(cpp_files) // 20)
+
+    for i, cpp_file in enumerate(cpp_files):
+        if (i + 1) % progress_interval == 0:
+            print(f"  Progress: {i+1}/{len(cpp_files)} files compared...")
+
+        python_file = python_dir / cpp_file.name
+
+        if not python_file.exists():
+            missing_python.append(cpp_file.name)
+            continue
+
+        cpp_data = load_detector_image(cpp_file)
+        py_data = load_detector_image(python_file)
+
+        if cpp_data is None or py_data is None:
+            continue
+
+        if cpp_data.shape != py_data.shape:
+            print(f"  {cpp_file.name}: Shape mismatch C++{cpp_data.shape} vs Py{py_data.shape}")
+            continue
+
+        metrics = compare_images(cpp_data, py_data, cpp_file.name)
+        results.append(metrics)
+
+        # Track empty images
+        if metrics['cpp_nonzero'] == 0 and metrics['py_nonzero'] == 0:
+            empty_both += 1
+
+        # Track images with differences
+        if metrics['cpp_only'] > 0 or metrics['py_only'] > 0 or metrics['max_abs_diff'] > 1e-6:
+            files_with_diffs.append(metrics)
+
+    # Check for extra Python files
+    cpp_names = {f.name for f in cpp_files}
+    missing_cpp = [f.name for f in python_files if f.name not in cpp_names]
+
+    print(f"\nCompared {len(results)} file pairs\n")
+
+    if missing_python:
+        print(f"  {len(missing_python)} files in C++ but not in Python:")
+        for name in missing_python[:5]:
+            print(f"    {name}")
+        if len(missing_python) > 5:
+            print(f"    ... and {len(missing_python) - 5} more")
+        print()
+
+    if missing_cpp:
+        print(f"  {len(missing_cpp)} files in Python but not in C++:")
+        for name in missing_cpp[:5]:
+            print(f"    {name}")
+        if len(missing_cpp) > 5:
+            print(f"    ... and {len(missing_cpp) - 5} more")
+        print()
+
+    if len(results) == 0:
+        print("No files were successfully compared!")
+        return 1
+
+    # Filter to non-empty results for statistics
+    nonempty_results = [r for r in results if r['cpp_nonzero'] > 0 or r['py_nonzero'] > 0]
+
+    print("=" * 80)
+    print("Summary Statistics")
+    print("=" * 80)
+
+    print(f"\nFile counts:")
+    print(f"  Total compared:       {len(results)}")
+    print(f"  Both empty:           {empty_both}")
+    print(f"  With content:         {len(nonempty_results)}")
+    print(f"  With differences:     {len(files_with_diffs)}")
+
+    if nonempty_results:
+        # Pixel overlap
+        total_cpp_px = sum(r['cpp_nonzero'] for r in nonempty_results)
+        total_py_px = sum(r['py_nonzero'] for r in nonempty_results)
+        total_both = sum(r['both_nonzero'] for r in nonempty_results)
+        total_cpp_only = sum(r['cpp_only'] for r in nonempty_results)
+        total_py_only = sum(r['py_only'] for r in nonempty_results)
+
+        print(f"\nPixel Overlap (across all images):")
+        print(f"  C++ nonzero pixels:   {total_cpp_px}")
+        print(f"  Python nonzero pixels: {total_py_px}")
+        print(f"  Both nonzero:         {total_both}")
+        print(f"  C++ only:             {total_cpp_only}")
+        print(f"  Python only:          {total_py_only}")
+        if total_cpp_px > 0:
+            print(f"  Match rate (vs C++):  {total_both / total_cpp_px * 100:.4f}%")
+        if total_py_px > 0:
+            print(f"  Pixel ratio (Py/C++): {total_py_px / total_cpp_px:.4f}")
+
+        max_abs_diffs = [r['max_abs_diff'] for r in nonempty_results]
+        mean_abs_diffs = [r['mean_abs_diff'] for r in nonempty_results]
+        max_rel_diffs = [r['max_rel_diff'] for r in nonempty_results if r['both_nonzero'] > 0]
+        correlations = [r['correlation'] for r in nonempty_results
+                        if not (isinstance(r['correlation'], float) and np.isnan(r['correlation']))]
+
+        print(f"\nAbsolute Differences:")
+        print(f"  Max across all files:  {max(max_abs_diffs):.6e}")
+        print(f"  Mean max difference:   {np.mean(max_abs_diffs):.6e}")
+        print(f"  Median max difference: {np.median(max_abs_diffs):.6e}")
+        print(f"  Mean avg difference:   {np.mean(mean_abs_diffs):.6e}")
+
+        if max_rel_diffs:
+            print(f"\nRelative Differences (at overlapping pixels):")
+            print(f"  Max relative error:    {max(max_rel_diffs):.6e}")
+            print(f"  Mean max rel error:    {np.mean(max_rel_diffs):.6e}")
+            print(f"  Median max rel error:  {np.median(max_rel_diffs):.6e}")
+
+        if correlations:
+            valid_corr = [c for c in correlations if not np.isnan(c)]
+            if valid_corr:
+                print(f"\nCorrelation:")
+                print(f"  Mean correlation:      {np.mean(valid_corr):.6f}")
+                print(f"  Min correlation:       {min(valid_corr):.6f}")
+
+        # Intensity comparison
+        total_cpp_sum = sum(r['cpp_sum'] for r in nonempty_results)
+        total_py_sum = sum(r['py_sum'] for r in nonempty_results)
+        print(f"\nTotal Intensity:")
+        print(f"  C++ total:             {total_cpp_sum:.6f}")
+        print(f"  Python total:          {total_py_sum:.6f}")
+        if total_cpp_sum > 0:
+            print(f"  Ratio (Py/C++):        {total_py_sum / total_cpp_sum:.6f}")
+
+    # Show worst offenders
+    if files_with_diffs:
+        print(f"\nWorst 10 files by pixel mismatch (C++-only + Py-only):")
+        worst_px = sorted(files_with_diffs,
+                          key=lambda r: r['cpp_only'] + r['py_only'], reverse=True)[:10]
+        for r in worst_px:
+            print(f"  {r['filename']:30s}  cpp_only={r['cpp_only']:4d}  "
+                  f"py_only={r['py_only']:4d}  max_rel={r['max_rel_diff']:.2e}")
+
+        print(f"\nWorst 10 files by max relative diff:")
+        worst_rel = sorted(files_with_diffs,
+                           key=lambda r: r['max_rel_diff'], reverse=True)[:10]
+        for r in worst_rel:
+            print(f"  {r['filename']:30s}  max_rel={r['max_rel_diff']:.6e}  "
+                  f"cpp_px={r['cpp_nonzero']:5d}  py_px={r['py_nonzero']:5d}")
+
+    # Pass/fail
+    print("\n" + "=" * 80)
+    print("Pass/Fail Assessment")
+    print("=" * 80)
+
+    passed = True
+
+    if total_cpp_px > 0:
+        match_rate = total_both / total_cpp_px
+        if match_rate > 0.99:
+            print(f"  PASS: Pixel match rate {match_rate*100:.2f}% > 99%")
+        else:
+            print(f"  FAIL: Pixel match rate {match_rate*100:.2f}% <= 99%")
+            passed = False
+
+    if max_rel_diffs:
+        max_rel = max(max_rel_diffs)
+        if max_rel < 0.01:
+            print(f"  PASS: Max relative error {max_rel:.2e} < 1%")
+        else:
+            print(f"  FAIL: Max relative error {max_rel:.2e} >= 1%")
+            passed = False
+
+    if total_cpp_px > 0:
+        px_ratio = total_py_px / total_cpp_px
+        if 0.99 < px_ratio < 1.01:
+            print(f"  PASS: Pixel count ratio {px_ratio:.4f} within 1%")
+        else:
+            print(f"  FAIL: Pixel count ratio {px_ratio:.4f} outside 1%")
+            passed = False
+
+    print()
+    if passed:
+        print("=" * 80)
+        print("ALL TESTS PASSED - Python and C++ outputs match!")
+        print("=" * 80)
+        return 0
+    else:
+        print("=" * 80)
+        print("TESTS FAILED - Outputs differ beyond threshold")
+        print("=" * 80)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/Examples/Example2.ManyGrains/run_python_simulation.py
+++ b/Examples/Example2.ManyGrains/run_python_simulation.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""
+Run Python IceNine forward simulation for Example2.ManyGrains.
+
+Compares against C++ IceNine output in ScatteringData/.
+Python output goes to ScatteringData_Python/.
+
+Usage:
+    cd Examples/Example2.ManyGrains
+    uv run python run_python_simulation.py
+"""
+
+import sys
+from pathlib import Path
+import time
+
+# Add icenine_py to Python path
+REPO_ROOT = Path(__file__).parent.parent.parent
+sys.path.insert(0, str(REPO_ROOT / "icenine_py"))
+
+from icenine.config_file import ConfigFile
+from icenine.forward_simulation import ForwardSimulation
+
+
+def main():
+    """Run Python forward simulation."""
+
+    import os
+    example_dir = Path(__file__).parent
+    os.chdir(example_dir)
+    config_path = example_dir / "ConfigFiles" / "Example2.Simulation.config"
+
+    print("=" * 70)
+    print("Python IceNine Forward Simulation - Example2.ManyGrains")
+    print("=" * 70)
+    print(f"\nConfig file: {config_path}")
+    print(f"Working directory: {example_dir}\n")
+
+    # Load configuration
+    print("Loading configuration...")
+    config = ConfigFile.from_file(str(config_path))
+
+    print(f"  Sample: {config.sample_filename}")
+    print(f"  Structure: {config.structure_filename}")
+    print(f"  Beam energy: {config.beam_energy} keV")
+    print(f"  Max Q: {config.max_q} A^-1")
+    print(f"  Detectors: {config.num_detectors}")
+    print(f"  Original output: {config.out_file_basename}")
+
+    # Use same basename as C++ for easy comparison
+    config.out_file_basename = "500Grains.sim"
+
+    print(f"  Modified output: {config.out_file_basename}")
+    print()
+
+    # Clean old Python output
+    python_dir = example_dir / "ScatteringData_Python"
+    if python_dir.exists():
+        old_files = list(python_dir.glob("*.d*"))
+        if old_files:
+            print(f"Cleaning {len(old_files)} old Python output files...")
+            for f in old_files:
+                f.unlink()
+
+    # Create simulator
+    print("Initializing simulator...")
+    simulator = ForwardSimulation(config)
+
+    # Run simulation
+    print("=" * 70)
+    print("Starting forward simulation...")
+    print("=" * 70)
+    start_time = time.time()
+
+    try:
+        images = simulator.simulate_detector_images(
+            output_dir=python_dir
+        )
+
+        elapsed = time.time() - start_time
+
+        print("=" * 70)
+        print("Simulation completed successfully!")
+        print("=" * 70)
+        print(f"  Omega steps: {len(images)}")
+        print(f"  Detectors: {len(images[0]) if images else 0}")
+        print(f"  Total files: {len(images) * len(images[0]) if images else 0}")
+        print(f"  Time elapsed: {elapsed:.2f} seconds ({elapsed/60:.2f} minutes)")
+        print(f"  Output directory: ScatteringData_Python/")
+        print()
+
+        # Compare file counts
+        cpp_dir = example_dir / "ScatteringData"
+        cpp_files = list(cpp_dir.glob("*.d*"))
+        python_files = list(python_dir.glob("*.d*"))
+
+        print("File count comparison:")
+        print(f"  C++ output: {len(cpp_files)} files")
+        print(f"  Python output: {len(python_files)} files")
+
+        if len(cpp_files) == len(python_files):
+            print("  File counts match!")
+        else:
+            print(f"  Mismatch: {len(python_files) - len(cpp_files):+d} files")
+
+        print()
+        print("Next step: Run compare_outputs.py to validate numerical agreement")
+
+    except Exception as e:
+        print("=" * 70)
+        print("Simulation failed!")
+        print("=" * 70)
+        print(f"Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/icenine_py/MIGRATION_HISTORY.md
+++ b/icenine_py/MIGRATION_HISTORY.md
@@ -120,6 +120,26 @@ C++ vs Python forward simulation comparison using three-voxel test case (360 det
 - `forward_simulation.py:_simulate_peaks()` — Triple loop: voxels × reflections × omega solutions. Uses `range_map.angle_to_wedge_index()` for omega bin mapping. Peak filter (`XDMEtaAcceptFn`) applies Lorentz-polarization correction: `I = I_form / (|sin(η)| × sin(2θ))`.
 - Omega-to-bin mapping: `SimulationRange._build_index_list()` marks only the CENTER bin of each wedge, matching C++ `SimulationData.h:Set()`. For 180 individual 1° wedges, all 180 bins have valid indices.
 
+### Performance Optimization — 6x Forward Simulation Speedup
+
+Profiling the ManyGrains test (24,570 voxels, 112 reflections, 180 omega steps) revealed torch scalar operation overhead as the bottleneck. Each per-element torch tensor op has ~10-50µs Python overhead; with ~3,360 torch ops per voxel this dominated runtime at ~58ms/voxel (~22min total).
+
+**Optimizations applied:**
+1. **Batched Bragg solving**: Single `get_scattering_omegas_torch()` call per voxel with all reflections stacked as (N,3) tensor, instead of N individual calls
+2. **Pre-computed detector geometry**: Detector plane normals, origins, unit vectors, and pixel parameters extracted as plain Python floats before the voxel loop
+3. **Pure-Python inner loop**: Replaced torch scalar tensor ops with `math` module for rotation, ray-plane intersection, and lab-to-pixel conversion
+4. **Functional rotation**: Compute Rz(omega) @ base_rotation as inline float math instead of mutating/restoring sample state per omega
+
+**Result**: 9.3ms/voxel (down from 58.2ms), ~4.5min for full ManyGrains simulation.
+
+**ManyGrains validation**: 99.97% pixel match rate (7,422,506 / 7,424,450), pixel count ratio 1.0000, total intensity ratio 1.000000, mean correlation 0.9996. Remaining ~0.03% mismatches are omega bin-boundary rounding (same as ThreeVoxels).
+
+**Note on differentiability**: The inner loop now uses plain floats (not torch autograd). This is acceptable because forward simulation generates images for comparison and doesn't need gradients. The proper differentiable path would batch ALL voxels into large tensors (matrix ops on thousands of voxels simultaneously), which is a separate effort.
+
+**Diagnostic scripts in `Examples/Example2.ManyGrains/`:**
+- `run_python_simulation.py` — runs full forward simulation (24,570 voxels)
+- `compare_outputs.py` — statistical comparison with pass/fail criteria
+
 **Diagnostic scripts in `Examples/Example2.ThreeVoxels/`:**
 - `run_python_simulation.py` — runs full forward simulation
 - `compare_outputs.py` / `compare_pixel_overlap.py` — pixel comparison

--- a/icenine_py/icenine/forward_simulation.py
+++ b/icenine_py/icenine/forward_simulation.py
@@ -12,6 +12,7 @@ Author: S. F. Li
 
 from typing import List, Optional
 from pathlib import Path
+import math
 import numpy as np
 import torch
 
@@ -23,6 +24,11 @@ from .detector import Detector
 from .image_data import ImageData
 from .peak_filters import XDMEtaAcceptFn
 from .constants import KEV_OVER_HBAR_C_IN_ANG
+from .diffraction_core import (
+    get_scattering_omegas_torch,
+    get_reflection_vector,
+)
+from .geometry import Ray
 
 
 class ForwardSimulation:
@@ -180,169 +186,243 @@ class ForwardSimulation:
         """
         Core simulation loop: iterate over voxels, reflections, and omegas.
 
-        This is the computational kernel of the forward simulation.
-
-        Args:
-            images: 2D list of detector images to accumulate into
-            detector_list: List of detector geometries
-            sample: Sample with voxel grid
-            range_map: Omega range to index mapping
+        Optimized version:
+        - Batches Bragg solving per-voxel (all reflections at once)
+        - Uses functional rotations (no sample mutation/restore)
+        - Pure Python floats in inner loop (avoids torch scalar overhead)
+        - Pre-computes all detector geometry and reciprocal vectors
 
         C++ Reference:
             ForwardSimulation.cpp:200-284 SimulatePeaks
-
-        Algorithm:
-            FOR each voxel v in sample:
-                Get crystal structure for voxel phase
-                Get reciprocal vectors G_hkl from structure
-
-                FOR each reflection G_hkl:
-                    Transform to lab frame: G' = O * G_hkl
-                    Solve Bragg condition for omega angles
-
-                    IF peak is observable:
-                        FOR each omega solution (ω₁, ω₂):
-                            Find omega index in range map
-                            IF omega in valid range:
-                                Rotate sample to omega
-                                Project voxel onto detector(s)
-                                Add intensity to image[omega_index][detector_index]
-                                Reset sample orientation
-
-        Performance:
-            - C++ cannot parallelize due to sparse matrix memory access
-            - Python version could potentially use thread-safe image accumulation
-            - Progress reported every 10000 voxels
         """
-        # Create peak acceptance filter
-        # C++: HEDM::XDMEtaAcceptFn FAcceptFn(-oExpSetup.GetEtaLimit(), oExpSetup.GetEtaLimit())
         eta_limit = self.exp_setup.get_eta_limit()
-
-        # Calculate wavenumber for Bragg angle calculations
-        # C++: Float fWavenumber = PhysicalConstants::keV_over_hbar_c_in_ang * oExpSetup.GetBeamEnergy()
         wavenumber = KEV_OVER_HBAR_C_IN_ANG * self.exp_setup.beam_energy
-
-        # Get crystal structures
-        # C++: const vector<CUnitCell> & oCryStructList = oCurrentLayer.GetStructureList()
+        beam_energy = self.exp_setup.beam_energy
+        beam_deflection = self.exp_setup.get_beam_deflection_chi_laue()
+        beam_dir_t = self.simulator.beam_direction
+        bd0, bd1, bd2 = beam_dir_t[0].item(), beam_dir_t[1].item(), beam_dir_t[2].item()
         structure_list = sample.get_structure_list()
-
-        # Get voxel grid
-        # C++: std::shared_ptr<CMic> pMic = std::dynamic_pointer_cast<CMic>(oCurrentLayer.GetMic())
         mic = sample.get_mic()
         voxel_list = mic.voxels
+        num_detectors = len(detector_list)
+
+        # Pre-compute detector geometry as plain Python floats
+        det_geom = []
+        for det in detector_list:
+            plane = det.detector_plane
+            pn = plane.normal
+            dp = det._position
+            dco = det._lab_frame_coord_origin
+            bj = det._lab_frame_basis_j
+            bk = det._lab_frame_basis_k
+            det_geom.append((
+                pn[0].item(), pn[1].item(), pn[2].item(), plane.d.item(),
+                dp[0].item(), dp[1].item(), dp[2].item(),
+                dco[0].item(), dco[1].item(), dco[2].item(),
+                bj[0].item(), bj[1].item(), bj[2].item(),
+                bk[0].item(), bk[1].item(), bk[2].item(),
+                det.pixel_half_width, det.pixel_half_height,
+                det.pixel_width, det.pixel_height,
+            ))
+
+        # Pre-compute reciprocal vector tensors per phase (torch for batched Bragg)
+        # and plain float arrays for inner loop
+        phase_data_torch = {}
+        phase_data_float = {}
+        for phase_idx, structure in enumerate(structure_list):
+            recp_vecs = structure.get_reflection_vectors()
+            if not recp_vecs:
+                continue
+            g_hkl_batch = torch.stack(
+                [torch.from_numpy(rv.q_vec).float() for rv in recp_vecs]
+            )
+            g_mag_batch = torch.tensor(
+                [rv.q_mag for rv in recp_vecs], dtype=torch.float32
+            )
+            intensities_list = [rv.intensity for rv in recp_vecs]
+            sin_theta = g_mag_batch / (2.0 * wavenumber)
+            sin_2theta = torch.sin(2.0 * torch.asin(sin_theta))
+            sin_2theta_list = sin_2theta.tolist()
+
+            phase_data_torch[phase_idx] = (g_hkl_batch, g_mag_batch)
+            phase_data_float[phase_idx] = (intensities_list, sin_2theta_list)
+
+        # Get base sample-to-lab matrix as plain floats
+        bm = sample.sample_to_lab_matrix
+        br00, br01, br02 = bm[0, 0].item(), bm[0, 1].item(), bm[0, 2].item()
+        br10, br11, br12 = bm[1, 0].item(), bm[1, 1].item(), bm[1, 2].item()
+        br20, br21, br22 = bm[2, 0].item(), bm[2, 1].item(), bm[2, 2].item()
+        bt0, bt1, bt2 = bm[0, 3].item(), bm[1, 3].item(), bm[2, 3].item()
+
+        _cos = math.cos
+        _sin = math.sin
+        _sqrt = math.sqrt
+        _atan2 = math.atan2
+        _fabs = math.fabs
 
         print(f"Simulating {len(voxel_list)} voxels...")
 
-        # Main simulation loop
-        # C++: for(vector<SVoxel>::const_iterator pCurVoxel = pMic->VoxelListBegin(); ...)
-        voxel_count = 0
+        for voxel_count, voxel in enumerate(voxel_list):
+            if (voxel_count + 1) % 10000 == 0:
+                print(f"  Voxel {voxel_count + 1}/{len(voxel_list)}")
 
-        for voxel in voxel_list:
-            voxel_count += 1
-
-            # Progress reporting
-            # C++: if(nVoxelCount % 10000 == 0) std::cout << nVoxelCount << std::endl
-            if voxel_count % 10000 == 0:
-                print(f"  Voxel {voxel_count}/{len(voxel_list)}")
-
-            # Get crystal structure for this voxel's phase
-            # C++: Int nCryStructIndex = pCurVoxel->nPhase
-            # C++: const vector<CRecpVector> & oRecipVectors = oCryStructList[nCryStructIndex].GetReflectionVectorList()
             phase_index = voxel.phase
-            if phase_index >= len(structure_list):
-                continue  # Skip invalid phase
+            if phase_index not in phase_data_torch:
+                continue
 
-            crystal_structure = structure_list[phase_index]
-            reciprocal_vectors = crystal_structure.get_reflection_vectors()
+            g_hkl_batch, g_mag_batch = phase_data_torch[phase_index]
+            intensities_list, sin_2theta_list = phase_data_float[phase_index]
 
-            # Get voxel orientation as PyTorch tensor
-            # C++: pCurVoxel->oOrientMatrix
+            # Transform all reciprocal vectors to lab frame at once (torch, batched)
             voxel_orientation = torch.from_numpy(voxel.orientation).float()
+            g_lab_batch = (voxel_orientation @ g_hkl_batch.T).T  # (N_refl, 3)
 
-            # Process each reflection
-            # C++: for(Size_Type nRecipIndex = 0; nRecipIndex < oRecipVectors.size(); nRecipIndex++)
-            for recp_idx, recp_vector in enumerate(reciprocal_vectors):
-                # Transform scattering vector to lab frame
-                # C++: SVector3 oScatteringVec = oRecipVectors[nRecipIndex].v
-                # C++: oScatteringVec.Transform(pCurVoxel->oOrientMatrix)  // g_hkl' = O * g_hkl
-                g_hkl = torch.from_numpy(recp_vector.q_vec).float()
-                g_lab = voxel_orientation @ g_hkl
-                g_magnitude = recp_vector.q_mag
+            # Batch Bragg solving for ALL reflections at once
+            bragg_result = get_scattering_omegas_torch(
+                g_lab_batch, g_mag_batch, beam_energy, beam_deflection
+            )
 
-                # Solve Bragg condition for omega angles
-                # C++: bool bPeakObservable = oSimulator.GetScatteringOmegas(fOmegaRes[0], fOmegaRes[1], ...)
-                from .diffraction_core import get_scattering_omegas_torch
+            # Extract observable results to plain Python lists
+            obs_mask = bragg_result.observable
+            if not obs_mask.any():
+                continue
 
-                result = get_scattering_omegas_torch(
-                    g_lab.unsqueeze(0),  # Add batch dimension
-                    torch.tensor([g_magnitude]),
-                    self.exp_setup.beam_energy,
-                    self.exp_setup.get_beam_deflection_chi_laue()
+            obs_indices = torch.where(obs_mask)[0].tolist()
+            g_lab_np = g_lab_batch.numpy()
+            omega1_np = bragg_result.omega1.numpy()
+            omega2_np = bragg_result.omega2.numpy()
+
+            # Pre-compute scattering directions as plain floats
+            obs_data = []
+            for idx in obs_indices:
+                gx, gy, gz = float(g_lab_np[idx, 0]), float(g_lab_np[idx, 1]), float(g_lab_np[idx, 2])
+                gnorm = _sqrt(gx * gx + gy * gy + gz * gz)
+                inv_gnorm = 1.0 / gnorm if gnorm > 0 else 0.0
+                sdx, sdy, sdz = gx * inv_gnorm, gy * inv_gnorm, gz * inv_gnorm
+                obs_data.append((
+                    sdx, sdy, sdz,
+                    float(omega1_np[idx]), float(omega2_np[idx]),
+                    intensities_list[idx], sin_2theta_list[idx]
+                ))
+
+            # Pre-compute voxel vertices as plain floats
+            x = float(voxel.position[0])
+            y = float(voxel.position[1])
+            z = float(voxel.position[2])
+            s = float(voxel.side_length)
+            sqrt3 = 1.7320508075688772
+            if voxel.points_up:
+                verts = (
+                    (x, y, z),
+                    (x + s, y, z),
+                    (x + s * 0.5, y + s * 0.5 * sqrt3, z),
+                )
+            else:
+                verts = (
+                    (x, y, z),
+                    (x + s * 0.5, y - s * 0.5 * sqrt3, z),
+                    (x + s, y, z),
                 )
 
-                if not result.observable[0]:
-                    continue  # Peak not observable
-
-                # Calculate sin(2θ) for Lorentz-polarization correction
-                # C++: Float fSinTheta = oRecipVectors[nRecipIndex].fMag / (Float(2.0) * fWavenumber)
-                # C++: FAcceptFn.fSin2Theta = sin(Float(2) * asin(fSinTheta))
-                sin_theta = g_magnitude / (2.0 * wavenumber)
-                sin_2theta = np.sin(2.0 * np.arcsin(sin_theta))
-
-                # Normalize scattering direction
-                # C++: oScatteringVec.Normalize()
-                # C++: const SVector3 & oScatteringDir = oScatteringVec
-                scattering_dir = g_lab / torch.norm(g_lab)
-
-                # Process both omega solutions
-                # C++: for(int i = 0; i < 2; i++)
-                omega_solutions = [result.omega1[0].item(), result.omega2[0].item()]
-
-                for omega in omega_solutions:
-                    # Find omega index in range map
-                    # C++: Size_Type nOmegaIndex = oRangeToIndexMap(fOmegaRes[i])
-                    # C++: if(nOmegaIndex != XDMSimulation::NoMatch)
+            # Process all observable peaks
+            for sdx, sdy, sdz, omega1, omega2, form_intensity, sin_2theta in obs_data:
+                for omega in (omega1, omega2):
                     omega_index = range_map.angle_to_wedge_index(omega)
-
                     if omega_index is None:
-                        continue  # Omega outside valid ranges
+                        continue
 
-                    # Save current sample orientation
-                    # C++: const SVector3 oCurOrientation = oCurrentLayer.GetOrientation()
-                    current_orientation = sample.get_orientation()
+                    # Compute Rz(omega) @ base_rotation as plain floats
+                    cos_w = _cos(omega)
+                    sin_w = _sin(omega)
+                    r00 = cos_w * br00 - sin_w * br10
+                    r01 = cos_w * br01 - sin_w * br11
+                    r02 = cos_w * br02 - sin_w * br12
+                    r10 = sin_w * br00 + cos_w * br10
+                    r11 = sin_w * br01 + cos_w * br11
+                    r12 = sin_w * br02 + cos_w * br12
+                    r20 = br20
+                    r21 = br21
+                    r22 = br22
 
-                    # Rotate sample to omega angle
-                    # C++: oCurrentLayer.RotateZ(fOmegaRes[i])
-                    sample.rotate_z(omega)
+                    # Transform scattering direction to lab frame
+                    lnx = r00 * sdx + r01 * sdy + r02 * sdz
+                    lny = r10 * sdx + r11 * sdy + r12 * sdz
+                    lnz = r20 * sdx + r21 * sdy + r22 * sdz
 
-                    # Create peak filter with this reflection's intensity
-                    # C++: FAcceptFn.fFormIntensity = oRecipVectors[nRecipIndex].fIntensity
-                    peak_filter = XDMEtaAcceptFn(
-                        min_eta=-eta_limit,
-                        max_eta=eta_limit,
-                        form_intensity=recp_vector.intensity,
-                        sin_2theta=sin_2theta
-                    )
+                    # Reflection: r_out = beam - 2*(beam·n)*n
+                    dot_bn = bd0 * lnx + bd1 * lny + bd2 * lnz
+                    two_dot = 2.0 * dot_bn
+                    rdx = bd0 - two_dot * lnx
+                    rdy = bd1 - two_dot * lny
+                    rdz = bd2 - two_dot * lnz
 
-                    # Project voxel onto all detectors simultaneously
-                    # C++ short-circuit: if any vertex misses any detector plane,
-                    # skip all detectors for this peak
-                    # C++: oSimulator.ProjectVoxel(oCurImageList, vDetectorList, oCurrentLayer,
-                    #                              *pCurVoxel, oScatteringDir, FAcceptFn)
-                    vertices = self._get_voxel_vertices(voxel)
-                    det_images = [images[omega_index][d] for d in range(len(detector_list))]
-                    self.simulator.project_voxel_multi_detector(
-                        det_images,
-                        detector_list,
-                        sample,
-                        vertices,
-                        scattering_dir,
-                        peak_filter
-                    )
+                    # Peak filter: eta acceptance + intensity
+                    rd_norm = _sqrt(rdx * rdx + rdy * rdy + rdz * rdz)
+                    inv_rd_norm = 1.0 / rd_norm if rd_norm > 0 else 0.0
+                    rdy_n = rdy * inv_rd_norm
+                    rdz_n = rdz * inv_rd_norm
+                    eta = _atan2(_fabs(rdy_n), _fabs(rdz_n))
 
-                    # Restore sample orientation
-                    # C++: oCurrentLayer.SetOrientation(oCurOrientation.m_fX, ...)
-                    sample.set_orientation(*current_orientation)
+                    if eta >= eta_limit:
+                        continue
+
+                    sin_eta = _sin(eta)
+                    intensity = form_intensity / (_fabs(sin_eta) * sin_2theta + 1e-10)
+
+                    # Project 3 vertices onto all detectors
+                    all_hit = True
+                    projected_pixels = [None] * (num_detectors * 3)
+
+                    for vi in range(3):
+                        vx, vy, vz = verts[vi]
+                        lab_vx = r00 * vx + r01 * vy + r02 * vz + bt0
+                        lab_vy = r10 * vx + r11 * vy + r12 * vz + bt1
+                        lab_vz = r20 * vx + r21 * vy + r22 * vz + bt2
+
+                        for di in range(num_detectors):
+                            dg = det_geom[di]
+                            # Ray-plane intersection
+                            denom = dg[0] * rdx + dg[1] * rdy + dg[2] * rdz
+                            if _fabs(denom) < 1e-8:
+                                all_hit = False
+                                break
+                            numer = -(dg[0] * lab_vx + dg[1] * lab_vy + dg[2] * lab_vz + dg[3])
+                            t = numer / denom
+                            if t <= 0:
+                                all_hit = False
+                                break
+
+                            # Intersection point
+                            ix = lab_vx + t * rdx
+                            iy = lab_vy + t * rdy
+                            iz = lab_vz + t * rdz
+
+                            # Lab to detector pixel coordinates
+                            px = ix - dg[4] - dg[7]
+                            py = iy - dg[5] - dg[8]
+                            pz = iz - dg[6] - dg[9]
+                            j_coord = px * dg[10] + py * dg[11] + pz * dg[12]
+                            k_coord = px * dg[13] + py * dg[14] + pz * dg[15]
+                            col = (j_coord + dg[16]) / dg[18]
+                            row = (k_coord + dg[17]) / dg[19]
+
+                            projected_pixels[di * 3 + vi] = (col, row)
+
+                        if not all_hit:
+                            break
+
+                    if not all_hit:
+                        continue
+
+                    # Rasterize onto each detector
+                    for di in range(num_detectors):
+                        base = di * 3
+                        v0 = torch.tensor(projected_pixels[base])
+                        v1 = torch.tensor(projected_pixels[base + 1])
+                        v2 = torch.tensor(projected_pixels[base + 2])
+                        images[omega_index][di].add_triangle_scanline(
+                            v0, v1, v2, intensity
+                        )
 
     def _get_voxel_vertices(self, voxel) -> torch.Tensor:
         """
@@ -351,33 +431,21 @@ class ForwardSimulation:
         Computes the 3 vertices of the equilateral triangle voxel,
         matching the C++ implementation in MicIO.h lines 300-315.
 
-        Args:
-            voxel: Voxel with position, side_length, and points_up fields
-
-        Returns:
-            Vertices tensor, shape (3, 3) - counter-clockwise winding
-
         C++ Reference:
             XDM++/libXDM/MicIO.h lines 300-315
         """
-        import math
-
         x = float(voxel.position[0])
         y = float(voxel.position[1])
         z = float(voxel.position[2])
         s = float(voxel.side_length)
 
         if voxel.points_up:
-            # UP triangle (direction=1) - counter-clockwise winding
-            # C++ MicIO.h lines 302-305
             vertices = torch.tensor([
                 [x,           y,                          z],
                 [x + s,       y,                          z],
                 [x + s / 2.0, y + s / 2.0 * math.sqrt(3.0), z],
             ], dtype=torch.float32)
         else:
-            # DOWN triangle (direction=2) - counter-clockwise winding
-            # C++ MicIO.h lines 310-313
             vertices = torch.tensor([
                 [x,           y,                            z],
                 [x + s / 2.0, y - s / 2.0 * math.sqrt(3.0), z],


### PR DESCRIPTION
## Summary
- **6x speedup** for forward simulation (58ms → 9.3ms per voxel) via batched Bragg solving, pre-computed detector geometry, and pure-Python math inner loop
- Validated on ManyGrains (24,570 voxels): 99.97% pixel match with C++, intensity ratio 1.000000
- Added Example2.ManyGrains test scripts (`run_python_simulation.py`, `compare_outputs.py`)
- Updated MIGRATION_HISTORY.md with optimization details and differentiability notes

## Test plan
- [x] `uv run pytest tests/` — 256 passed, 34 skipped, 0 failed
- [x] ThreeVoxels C++ vs Python comparison — pixel-exact match preserved
- [x] ManyGrains C++ vs Python comparison — 99.97% pixel match, all pass/fail criteria met
- [x] Code review agent — APPROVED (physics correctness, no state bugs, clean architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)