### PR TITLE
Add cost function benchmark tools and equivalence docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,6 +57,8 @@ uv run python script.py                  # run any Python script
 - **Degree/radian boundary**: `.mic` files store angles in degrees; conversion to radians happens at I/O boundaries. Config files have 15 parameters requiring degree-to-radian conversion.
 - **Batching required**: Single-element physics operations are too slow. All diffraction calculations must use batched PyTorch operations.
 - **Spatial indexing**: Always use `scipy.spatial.cKDTree` (not `KDTree`) — 10-100x faster, identical API.
+- **Q-max mismatch is intentional**: Simulation data may use Q-max=16 while reconstruction uses Q-max=8. This does NOT degrade reconstruction quality. The cost function does not penalize under-observed peaks — peaks beyond max_q are filtered out at `VoxelCostFunction.__init__` time. Both C++ and Python handle this identically. Fewer reciprocal vectors means fewer peaks in the metric (faster but less discriminating).
+- **Cost function angular sharpness**: The cost function (pixel overlap quality) is extremely sharp in orientation space — quality drops rapidly within 0.2–0.5 degrees of the correct orientation. This is fundamental Bragg diffraction physics (peaks are narrow in angle). Multi-level adaptive search is necessary: coarse Sukharev grid to find the basin, then fine MC refinement within it.
 
 ## Architecture
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,5 +88,55 @@ target_link_libraries(IceNine PRIVATE
 )
 
 # Set MPI compile flags
-target_compile_options(IceNine PRIVATE ${MPI_CXX_COMPILE_FLAGS}) 
+target_compile_options(IceNine PRIVATE ${MPI_CXX_COMPILE_FLAGS})
+
+#----------------------------
+# Cost Function Benchmark (standalone, no MPI main)
+#----------------------------
+set( Benchmark_FileList
+  "Src/CostFunctionBenchmark.cpp"
+  "Src/BoundarySelectionStrategies.cpp"
+  "Src/BreadthFirstReconstructor.cpp"
+  "Src/ConfigFile.cpp"
+  "Src/CostFunctions.cpp"
+  "Src/Detector.cpp"
+  "Src/DetectorFile.cpp"
+  "Src/DiscreteSearch.cpp"
+  "Src/ExperimentSetup.cpp"
+  "Src/ForwardSimulation.cpp"
+  "Src/ImageData.cpp"
+  "Src/InitFilesIO.cpp"
+  "Src/OptimizationConfig.cpp"
+  "Src/OrientationSearch.cpp"
+  "Src/Peak.cpp"
+  "Src/ReconstructionSetup.cpp"
+  "Src/ReconstructionStrategies.cpp"
+  "Src/Reconstructor.cpp"
+  "Src/Sample.cpp"
+  "Src/SearchDetails.cpp"
+  "Src/Simulation.cpp"
+  "Src/Utilities.cpp"
+  "Src/XDMClient.cpp"
+  "Src/XDMParallel.cpp"
+  "Src/XDMRaster.cpp"
+  "Src/XDMServer.cpp"
+  "Src/PaintGrid.cpp"
+)
+
+add_executable(CostFunctionBenchmark ${Benchmark_FileList})
+
+target_include_directories(CostFunctionBenchmark PRIVATE
+    ${PROJECT_SOURCE_DIR}/XDM++/libXDM
+    ${Boost_INCLUDE_DIRS}
+    ${MPI_CXX_INCLUDE_DIRS}
+)
+
+target_link_libraries(CostFunctionBenchmark PRIVATE
+    XDM++
+    Eigen3::Eigen
+    ${MPI_CXX_LIBRARIES}
+    ${Boost_LIBRARIES}
+)
+
+target_compile_options(CostFunctionBenchmark PRIVATE ${MPI_CXX_COMPILE_FLAGS})
 

--- a/Src/CostFunctionBenchmark.cpp
+++ b/Src/CostFunctionBenchmark.cpp
@@ -1,0 +1,431 @@
+//==============================================================================
+//  CostFunctionBenchmark.cpp
+//
+//  Standalone benchmark for profiling the IceNine cost function at per-operation
+//  granularity. Measures:
+//    1. Single GetScatteringOmegas call
+//    2. GetObservablePeaks (all reciprocal vectors)
+//    3. Single peak overlap: 0 detectors hit
+//    4. Single peak overlap: 1 detector hit
+//    5. Single peak overlap: 2 detectors hit
+//    6. Full VoxelCostFunction::operator() (single voxel)
+//
+//  Usage: ./CostFunctionBenchmark <ConfigFile>
+//  Example: ./CostFunctionBenchmark Examples/Example2.ThreeVoxels/ConfigFiles/ReconstructBenchmark.config
+//==============================================================================
+
+#include "ConfigFile.h"
+#include "ExperimentSetup.h"
+#include "ReconstructionSetup.h"
+#include "Simulation.h"
+#include "SearchTraits.h"
+#include "CostFunctions.h"
+#include "OverlapInfo.h"
+#include "Voxel.h"
+#include "Sample.h"
+#include "PeakFilters.h"
+#include "DiffractionCore.h"
+#include "MicIO.h"
+#include <chrono>
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <cmath>
+#include <numeric>
+#include <algorithm>
+
+using namespace std;
+using namespace CostFunctions;
+
+//------------------------------------------------------------------------------
+//  Timer helper
+//------------------------------------------------------------------------------
+struct BenchResult {
+  double mean_us;    // microseconds
+  double stddev_us;
+  double min_us;
+  int n_iters;
+};
+
+template<typename Fn>
+BenchResult benchmark(const string& name, int n_iters, Fn fn)
+{
+  // Warmup
+  for (int i = 0; i < std::min(3, n_iters); i++)
+    fn();
+
+  vector<double> times;
+  times.reserve(n_iters);
+
+  for (int i = 0; i < n_iters; i++) {
+    auto t0 = chrono::high_resolution_clock::now();
+    fn();
+    auto t1 = chrono::high_resolution_clock::now();
+    double us = chrono::duration<double, micro>(t1 - t0).count();
+    times.push_back(us);
+  }
+
+  double sum = accumulate(times.begin(), times.end(), 0.0);
+  double mean = sum / n_iters;
+
+  double sq_sum = 0;
+  for (auto t : times) sq_sum += (t - mean) * (t - mean);
+  double stddev = sqrt(sq_sum / n_iters);
+
+  double min_val = *min_element(times.begin(), times.end());
+
+  cout << fixed << setprecision(2);
+  cout << "  " << setw(45) << left << name
+       << "  mean=" << setw(10) << right << mean << " us"
+       << "  stddev=" << setw(8) << stddev << " us"
+       << "  min=" << setw(10) << min_val << " us"
+       << "  (n=" << n_iters << ")" << endl;
+
+  return {mean, stddev, min_val, n_iters};
+}
+
+//------------------------------------------------------------------------------
+//  Main
+//------------------------------------------------------------------------------
+int main(int argc, char* argv[])
+{
+  if (argc < 2) {
+    cerr << "Usage: " << argv[0] << " <ConfigFile>" << endl;
+    return 1;
+  }
+
+  string sConfigFile = argv[1];
+  cout << "=== IceNine Cost Function Benchmark ===" << endl;
+  cout << "Config: " << sConfigFile << endl;
+  cout << endl;
+
+  //--------------------------------------------
+  // Step 1: Initialize everything
+  //--------------------------------------------
+  cout << "--- Initialization ---" << endl;
+
+  CConfigFile oConfigFile;
+  if (!oConfigFile.InputConfigParameters(sConfigFile)) {
+    cerr << "ERROR: Failed to read config file: " << sConfigFile << endl;
+    return 1;
+  }
+
+  Reconstruction::ReconstructionSetup oSetup;
+  oSetup.InitializeWithDataFiles(oConfigFile);
+  cout << "  Config loaded, data files read." << endl;
+
+  const CXDMExperimentSetup& oExpSetup = oSetup.ExperimentalSetup();
+  CSample& oSample = oSetup.SampleGeometry();
+  const CSimulationData& oExpData = oSetup.Data();
+  const vector<CDetector>& oDetList = oExpSetup.GetDetectorList();
+  const XDMSimulation::CSimulationRange& oRangeMap = oExpSetup.GetRangeToIndexMap();
+
+  CSimulation oSimulator(oExpSetup);
+  cout << "  Simulator initialized." << endl;
+  cout << "  Detectors: " << oDetList.size() << endl;
+
+  //--------------------------------------------
+  // Step 2: Get voxel and reciprocal vectors
+  //--------------------------------------------
+  auto pMicBase = oSample.GetMic();
+  auto pMic = std::dynamic_pointer_cast<CMic>(pMicBase);
+  if (!pMic) {
+    cerr << "ERROR: Could not cast MicIOBase to CMic" << endl;
+    return 1;
+  }
+  const vector<SVoxel>& voxels = pMic->GetVoxels();
+  cout << "  Voxels in sample: " << voxels.size() << endl;
+
+  if (voxels.size() < 3) {
+    cerr << "ERROR: Need at least 3 voxels (using voxel index 2)" << endl;
+    return 1;
+  }
+
+  // Use voxel 2 (the one that reconstructs correctly in validation)
+  SVoxel oTestVoxel = voxels[2];
+  cout << "  Using voxel 2, phase=" << oTestVoxel.nPhase << endl;
+  cout << "  Voxel center: ("
+       << oTestVoxel.GetCenter().m_fX << ", "
+       << oTestVoxel.GetCenter().m_fY << ", "
+       << oTestVoxel.GetCenter().m_fZ << ")" << endl;
+  cout << "  Orientation matrix:" << endl;
+  for (int r = 0; r < 3; r++) {
+    cout << "    [";
+    for (int c = 0; c < 3; c++)
+      cout << setw(10) << setprecision(5) << oTestVoxel.oOrientMatrix.m[r][c];
+    cout << " ]" << endl;
+  }
+
+  const vector<CRecpVector>& oRecipVectors =
+    oSample.GetStructureList()[oTestVoxel.nPhase].GetReflectionVectorList();
+  cout << "  Reciprocal vectors: " << oRecipVectors.size() << endl;
+
+  //--------------------------------------------
+  // Step 3: Build cost function (same type chain as Reconstructor.h)
+  //--------------------------------------------
+  typedef Reconstruction::ReconstructionSetup::EtaAngularFilter PeakFilterT;
+  typedef OrientationSearch::GeneralSearchCostFn<
+    PeakFilterT, CSimulation,
+    CostFunctions::TrianglePixelOverlapCounter,
+    CostFunctions::DetectorOverlapCounter,
+    CostFunctions::XDMSampleVertexOverlapCounter,
+    CostFunctions::VoxelToVertices,
+    CostFunctions::VoxelCostFunction, SVoxel
+  > LocalSearchCostFunctions;
+
+  PeakFilterT oFilter = oSetup.EtaThresholdFilter();
+  LocalSearchCostFunctions oSearchCostFn(oFilter, oSimulator);
+  auto& oVoxelCostFn = oSearchCostFn.VoxelCostFn();
+
+  cout << endl;
+
+  //--------------------------------------------
+  // Benchmark 1: Single GetScatteringOmegas call
+  //--------------------------------------------
+  cout << "--- Benchmark 1: Single GetScatteringOmegas ---" << endl;
+  {
+    SVector3 g = oTestVoxel.oOrientMatrix * oRecipVectors[0].v;
+    Float fMag = oRecipVectors[0].fMag;
+    Float omega1, omega2;
+    int N = 100000;
+
+    benchmark("GetScatteringOmegas (single)", N, [&]() {
+      oSimulator.GetScatteringOmegas(omega1, omega2, g, fMag);
+    });
+
+    // Also benchmark all reciprocal vectors sequentially
+    benchmark("GetScatteringOmegas (all " + to_string(oRecipVectors.size()) + " recip vecs)", 1000, [&]() {
+      Float o1, o2;
+      for (size_t i = 0; i < oRecipVectors.size(); i++) {
+        SVector3 gi = oTestVoxel.oOrientMatrix * oRecipVectors[i].v;
+        oSimulator.GetScatteringOmegas(o1, o2, gi, oRecipVectors[i].fMag);
+      }
+    });
+  }
+  cout << endl;
+
+  //--------------------------------------------
+  // Benchmark 2: GetObservablePeaks (full)
+  //--------------------------------------------
+  cout << "--- Benchmark 2: GetObservablePeaks ---" << endl;
+  vector<SPeakInfo> oPeakInfoList;
+  {
+    int N = 1000;
+    benchmark("GetObservablePeaks (all recip vecs)", N, [&]() {
+      oPeakInfoList.clear();
+      oPeakInfoList.reserve(oRecipVectors.size() * 2);
+      oSimulator.GetObservablePeaks(oPeakInfoList, oTestVoxel.oOrientMatrix,
+                                     oRecipVectors, oDetList);
+    });
+    cout << "  Observable peaks generated: " << oPeakInfoList.size() << endl;
+  }
+  cout << endl;
+
+  //--------------------------------------------
+  // Benchmark 3-5: Per-peak overlap by detector hit count
+  //
+  // We run GenerateProjectedPixels + DetOverlapCounter for individual peaks
+  // to measure the cost of overlap computation by detector hit category.
+  //--------------------------------------------
+  cout << "--- Benchmark 3-5: Per-peak overlap (categorized by detector hits) ---" << endl;
+  {
+    // First, classify peaks by how many detectors they actually hit
+    vector<SVector3> oVertexList = oSearchCostFn.VertexExtractorFn()(oTestVoxel);
+
+    int n_hit_0 = 0, n_hit_1 = 0, n_hit_2 = 0;
+    int peak_0_det = -1, peak_1_det = -1, peak_2_det = -1;
+
+    // Use the full cost function internals to classify peaks
+    const SMatrix3x3 oCurOrientation = oSample.GetOrientationMatrix();
+    for (size_t p = 0; p < oPeakInfoList.size(); p++) {
+      if (!oPeakInfoList[p].bObservable) continue;
+      Size_Type nOmegaIndex = oRangeMap(oPeakInfoList[p].fOmega);
+      if (nOmegaIndex == XDMSimulation::NoMatch) continue;
+
+      // Save/restore sample orientation
+      oSample.RotateZ(oPeakInfoList[p].fOmega);
+      const SVector3& oNormal = oPeakInfoList[p].oScatteringDir;
+
+      int dets_hit = 0;
+      for (size_t d = 0; d < oDetList.size(); d++) {
+        bool all_hit = true;
+        for (int vi = 0; vi < 3; vi++) {
+          CRay oReflectedRay = DiffractionCore::BuildReflectedRay(
+            oSample, oVertexList[vi],
+            DiffractionCore::GetReflectedRayDir(oSample, oNormal, oExpSetup.GetXrayBeamDirection()));
+          Point pixel;
+          bool hit = DiffractionCore::GetIlluminatedPixel(pixel, oDetList[d], oReflectedRay);
+          if (!hit) { all_hit = false; break; }
+        }
+        if (all_hit) dets_hit++;
+      }
+
+      if (dets_hit == 0 && peak_0_det < 0) peak_0_det = p;
+      if (dets_hit == 1 && peak_1_det < 0) peak_1_det = p;
+      if (dets_hit == 2 && peak_2_det < 0) peak_2_det = p;
+      if (dets_hit == 0) n_hit_0++;
+      else if (dets_hit == 1) n_hit_1++;
+      else n_hit_2++;
+
+      oSample.SetOrientation(oCurOrientation);
+    }
+
+    cout << "  Peak classification: 0-det=" << n_hit_0
+         << " 1-det=" << n_hit_1 << " 2-det=" << n_hit_2 << endl;
+
+    // Now benchmark individual peak evaluations for each category
+    // We create single-peak PeakInfoLists and run CalculateDiffractionOverlap
+    auto& oVertexOverlapCounter = oSearchCostFn.VertexCostFn();
+
+    auto benchSinglePeak = [&](const string& label, int peakIdx, int N) {
+      if (peakIdx < 0) {
+        cout << "  " << setw(45) << left << label << "  SKIPPED (no such peak)" << endl;
+        return;
+      }
+      vector<SPeakInfo> singlePeak = { oPeakInfoList[peakIdx] };
+      benchmark(label, N, [&]() {
+        oVertexOverlapCounter.CalculateDiffractionOverlap(
+          oVertexList, singlePeak, oSample, oDetList, oRangeMap, oExpData);
+      });
+    };
+
+    benchSinglePeak("Single peak: 0 detectors hit", peak_0_det, 10000);
+    benchSinglePeak("Single peak: 1 detector hit", peak_1_det, 10000);
+    benchSinglePeak("Single peak: 2 detectors hit", peak_2_det, 10000);
+
+    // Benchmark: all peaks via CalculateDiffractionOverlap (without GetObservablePeaks)
+    benchmark("CalculateDiffractionOverlap (all " + to_string(oPeakInfoList.size()) + " peaks)", 100, [&]() {
+      oVertexOverlapCounter.CalculateDiffractionOverlap(
+        oVertexList, oPeakInfoList, oSample, oDetList, oRangeMap, oExpData);
+    });
+  }
+  cout << endl;
+
+  //--------------------------------------------
+  // Benchmark 6: Full VoxelCostFunction::operator()
+  //--------------------------------------------
+  cout << "--- Benchmark 6: Full VoxelCostFunction (single voxel) ---" << endl;
+  {
+    SOverlapInfo oResult;
+    int N = 100;
+
+    benchmark("VoxelCostFunction::operator()", N, [&]() {
+      oResult = oVoxelCostFn(oTestVoxel, oSample, oDetList, oRangeMap, oExpData);
+    });
+
+    Float fCost = 1.0f - oResult.fQuality;
+    Float fHitRatio = (oResult.nPixelOnDetector > 0) ?
+      Float(oResult.nPixelOverlap) / Float(oResult.nPixelOnDetector) : 0.0f;
+
+    cout << "  Result: quality=" << oResult.fQuality
+         << "  cost=" << fCost
+         << "  hit_ratio=" << fHitRatio << endl;
+    cout << "  Pixels: overlap=" << oResult.nPixelOverlap
+         << "  on_det=" << oResult.nPixelOnDetector << endl;
+    cout << "  Peaks: overlap=" << oResult.nPeakOverlap
+         << "  on_det=" << oResult.nPeakOnDetector << endl;
+  }
+  cout << endl;
+
+  //--------------------------------------------
+  // Per-peak diagnostic output (for C++/Python validation)
+  //--------------------------------------------
+  cout << "--- Per-Peak Diagnostics ---" << endl;
+  {
+    vector<SVector3> oVertexList = oSearchCostFn.VertexExtractorFn()(oTestVoxel);
+    auto& oVertexOverlapCounter = oSearchCostFn.VertexCostFn();
+
+    // Count observable peaks that pass omega filter
+    int nValidPeaks = 0;
+    for (size_t p = 0; p < oPeakInfoList.size(); p++) {
+      if (!oPeakInfoList[p].bObservable) continue;
+      Size_Type nOmegaIndex = oRangeMap(oPeakInfoList[p].fOmega);
+      if (nOmegaIndex == XDMSimulation::NoMatch) continue;
+      nValidPeaks++;
+    }
+    cout << "  Observable peaks (after eta filter): " << oPeakInfoList.size()
+         << " (valid omega: " << nValidPeaks << ")" << endl;
+    cout << endl;
+
+    cout << "  " << setw(4) << right << "Peak" << "  "
+         << setw(10) << right << "omega_deg" << "  "
+         << setw(8) << right << "pix_ovlp" << "  "
+         << setw(8) << right << "pix_det" << "  "
+         << setw(7) << right << "pk_ovlp" << "  "
+         << setw(6) << right << "pk_det" << "  "
+         << setw(10) << right << "n_det_ovlp" << "  "
+         << setw(10) << right << "quality_i" << endl;
+
+    cout << "  " << setw(4) << right << "----" << "  "
+         << setw(10) << right << "----------" << "  "
+         << setw(8) << right << "--------" << "  "
+         << setw(8) << right << "--------" << "  "
+         << setw(7) << right << "-------" << "  "
+         << setw(6) << right << "------" << "  "
+         << setw(10) << right << "----------" << "  "
+         << setw(10) << right << "----------" << endl;
+
+    int peakCount = 0;
+    for (size_t p = 0; p < oPeakInfoList.size(); p++) {
+      if (!oPeakInfoList[p].bObservable) continue;
+
+      vector<SPeakInfo> singlePeak = { oPeakInfoList[p] };
+      SOverlapInfo oPeakResult = oVertexOverlapCounter.CalculateDiffractionOverlap(
+        oVertexList, singlePeak, oSample, oDetList, oRangeMap, oExpData);
+
+      Float omega_deg = oPeakInfoList[p].fOmega * 180.0 / M_PI;
+      Float quality_i = oPeakResult.fQuality;
+      if (oPeakResult.nPixelOnDetector == 0)
+        quality_i = -1.0;
+
+      cout << "  " << setw(4) << right << peakCount << "  "
+           << setw(10) << setprecision(4) << fixed << right << omega_deg << "  "
+           << setw(8) << right << oPeakResult.nPixelOverlap << "  "
+           << setw(8) << right << oPeakResult.nPixelOnDetector << "  "
+           << setw(7) << right << oPeakResult.nPeakOverlap << "  "
+           << setw(6) << right << oPeakResult.nPeakOnDetector << "  "
+           << setw(10) << right << oPeakResult.nDetectorsOverlap << "  "
+           << setw(10) << setprecision(6) << right << quality_i << endl;
+
+      peakCount++;
+    }
+
+    cout << endl;
+
+    // Recompute aggregate quality from per-peak data
+    cout << "--- Aggregate Quality Recomputation ---" << endl;
+    Float runningQuality = 0.0;
+    int nPoints = 0;
+    peakCount = 0;
+    for (size_t p = 0; p < oPeakInfoList.size(); p++) {
+      if (!oPeakInfoList[p].bObservable) continue;
+
+      vector<SPeakInfo> singlePeak = { oPeakInfoList[p] };
+      SOverlapInfo oPeakResult = oVertexOverlapCounter.CalculateDiffractionOverlap(
+        oVertexList, singlePeak, oSample, oDetList, oRangeMap, oExpData);
+
+      if (oPeakResult.nPixelOnDetector > 0) {
+        Float curQuality = oPeakResult.fQuality;
+        runningQuality += (curQuality - runningQuality) / Float(nPoints + 1);
+        nPoints++;
+      }
+      peakCount++;
+    }
+
+    cout << "  Recomputed quality: " << setprecision(6) << runningQuality
+         << "  (n_points=" << nPoints << ")" << endl;
+
+    // Re-run full eval to show comparison
+    SOverlapInfo oFinalResult = oVoxelCostFn(oTestVoxel, oSample, oDetList, oRangeMap, oExpData);
+    cout << "  VoxelCostFunction quality: " << setprecision(6) << oFinalResult.fQuality
+         << "  (n_points implied from peaks)" << endl;
+  }
+  cout << endl;
+
+  //--------------------------------------------
+  // Summary
+  //--------------------------------------------
+  cout << "=== Benchmark Complete ===" << endl;
+
+  return 0;
+}

--- a/icenine_py/MIGRATION_HISTORY.md
+++ b/icenine_py/MIGRATION_HISTORY.md
@@ -393,3 +393,28 @@ Simulation data may use Q-max=16 Å⁻¹ while reconstruction uses Q-max=8 Å⁻
 ### Cost Function Angular Sharpness
 
 The cost function (pixel overlap quality) is extremely sharp in orientation space — quality drops rapidly within 0.2–0.5 degrees of the correct orientation. This is fundamental Bragg diffraction physics: diffraction peaks are narrow in angle, so even small orientation errors cause peaks to miss entirely. This sharpness motivates the multi-level adaptive search: coarse Sukharev grid sampling to find the correct basin, then fine MC refinement within it.
+
+### Cost Function Validation — C++ vs Python (2026-03-22)
+
+Apples-to-apples comparison using identical config (`ReconstructBenchmark.config`), identical data (`ScatteringData/`), and matched `eta_limit=86°`.
+
+**Tool**: `icenine_py/benchmarks/validate_cost_function.py` (Python), `Src/CostFunctionBenchmark.cpp` (C++ with per-peak diagnostics).
+
+**Results (voxel 2, ground truth orientation):**
+
+| Metric | C++ | Python | Status |
+|--------|-----|--------|--------|
+| quality | 0.923077 | 0.916667 | 0.006 diff |
+| pixel_overlap | 159 | 159 | Exact |
+| pixel_on_detector | 159 | 160 | 1 pixel diff |
+| peak_overlap | 52 | 52 | Exact |
+| peak_on_detector | 52 | 52 | Exact |
+| n_quality_points | 52 | 52 | Exact |
+
+**Root cause of original 0.92 vs 0.67 gap (now resolved):**
+
+1. **eta_limit not passed**: Python `VoxelCostFunction` defaulted to `π/2` (90°) instead of config's 86°. More peaks passed the eta filter, diluting quality. Fix: always pass `eta_limit=config.eta_limit`.
+2. **Different data directory**: C++ reads `ScatteringData/` (no headers), Python was reading `ScatteringData_Python/` (with headers). Same pixel coordinates but different format.
+3. **Different config file**: C++ benchmark used `ReconstructBenchmark.config` (MaxQ=8), Python used `Example2.Simulation.config` (MaxQ=16, but overridden by `max_q=8.0`).
+
+**Remaining 0.006 quality difference**: A single peak at omega=-61.23° rasterizes 3 pixels in Python vs 2 in C++. One pixel sits on the triangle edge — borderline rounding in ray-plane intersection. This is within acceptable tolerance and does not indicate a formula bug.

--- a/icenine_py/MIGRATION_HISTORY.md
+++ b/icenine_py/MIGRATION_HISTORY.md
@@ -355,3 +355,41 @@ Python recovers all 3 orientations to within 0.01° of ground truth. Voxel 1's p
 **Progress statements**: Added `flush=True` progress reporting to `reconstructor.py` (per-level timing, candidate counts, convergence status) and `experimental_data.py` (image loading progress) for real-time visibility during long runs.
 
 **Files changed**: `reconstructor.py` (progress statements), `experimental_data.py` (loading progress), `Examples/Example2.ThreeVoxels/run_python_reconstruction.py` (benchmark script).
+
+### Cost Function C++/Python Equivalence Review
+
+Systematic comparison of the C++ and Python cost function implementations. All code paths verified line-by-line.
+
+**Equivalence table:**
+
+| Aspect | C++ Source | Python Source | Match? |
+|--------|-----------|---------------|--------|
+| Scattering omegas (Bragg condition) | `Simulation.cpp:65-119` | `diffraction_core.py:59-194` | Yes |
+| Observable peak generation | `Simulation.cpp:130-152` | `VoxelCostFunction.evaluate()` | Yes |
+| Q-max filtering | `ExperimentSetup.cpp:SetDetectionLimit()` | `VoxelCostFunction.__init__` line 657 | Yes |
+| Eta filtering | `Simulation.tmpl.cpp GetProjectedVertices` | `evaluate()` lines 743-750 | Yes (different location, same effect) |
+| UpdateQuality (Welford mean) | `OverlapInfo.h:129-147` | `OverlapInfo.update_quality()` | Yes (fixed in Phase 8) |
+| CountQualifiedPeaks | `OverlapInfo.tmpl.cpp:76-139` | `count_qualified_peaks()` | Yes |
+| Quality = pixel_ratio × det_ratio | `OverlapInfo.h:136-138` | Lines 95-98 | Yes |
+| PixelBasedPeakOverlapCounter | `OverlapInfo.h:336-382` | Lines 522-550 | Yes |
+| ShapePixelOverlapCounter | `OverlapInfo.h:458-519` | Lines 551-569 | **Fixed** (detector_lit) |
+
+**Bug found and fixed: `detector_lit` handling in triangle rasterization mode**
+
+In `pixel_radius == 0` mode (full triangle rasterization), Python was setting `detector_lit[det_idx] = True` unconditionally whenever all 3 vertices intersected the detector plane (ray-plane hit). C++ (`ShapePixelOverlapCounter<SVoxel>`, OverlapInfo.h:498-517) only sets `bDetectorLit = true` when either:
+- `nPixelOverlap > 0` (overlap found), OR
+- At least one vertex is within detector bounds (`IsInBound`)
+
+If all vertices project outside the detector image, C++ correctly leaves `bDetectorLit = false`. This affects `count_qualified_peaks` contiguous detector validation.
+
+**Fix**: In both serial (`calculate_diffraction_overlap`, line 316) and batched (`calculate_diffraction_overlap_batched`, line 519) paths, moved `detector_lit` assignment after the overlap computation. Set it based on `n_lit_int > 0` (triangle has in-bounds pixels, equivalent to C++ `IsInBound`) or `n_overlap_int > 0`. The `pixel_radius > 0` branch was already correct (explicitly checks bounds via `found_in_bounds`).
+
+**Note on `GetConfidence` semantics**: C++ `GetConfidence()` returns `nPeakOverlap / nPeakOnDetector` (fraction of peaks with overlap). Python `OverlapInfo.confidence` returns `quality` (Welford mean of per-peak quality contributions). The Python reconstructor uses `hit_ratio` (= `pixel_overlap / pixel_on_detector`) for convergence decisions, which is closer to the C++ `GetHitRatio()`.
+
+### Q-max Behavior Clarification
+
+Simulation data may use Q-max=16 Å⁻¹ while reconstruction uses Q-max=8 Å⁻¹. This does NOT degrade reconstruction quality. The cost function does not penalize under-observed peaks — peaks beyond max_q are filtered out at `VoxelCostFunction.__init__` time (line 657). Both C++ and Python handle this identically (C++ filters via `ExperimentSetup::SetDetectionLimit()`, Python via list comprehension on `rv.q_mag <= max_q`). Using fewer reciprocal vectors simply means fewer peaks contribute to the quality metric — faster evaluation but less discriminating.
+
+### Cost Function Angular Sharpness
+
+The cost function (pixel overlap quality) is extremely sharp in orientation space — quality drops rapidly within 0.2–0.5 degrees of the correct orientation. This is fundamental Bragg diffraction physics: diffraction peaks are narrow in angle, so even small orientation errors cause peaks to miss entirely. This sharpness motivates the multi-level adaptive search: coarse Sukharev grid sampling to find the correct basin, then fine MC refinement within it.

--- a/icenine_py/benchmarks/validate_cost_function.py
+++ b/icenine_py/benchmarks/validate_cost_function.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Cost Function Validation — apples-to-apples C++ vs Python comparison.
+
+Uses identical config (ReconstructBenchmark.config) and data (ScatteringData/)
+as the C++ CostFunctionBenchmark to validate quality metric agreement.
+
+Key differences from benchmark_cost_function.py:
+  - Uses ReconstructBenchmark.config (not Example2.Simulation.config)
+  - Reads from ScatteringData/ (not ScatteringData_Python/)
+  - Passes eta_limit from config (86° → radians)
+  - Prints per-peak diagnostic output for comparison with C++
+
+Usage:
+  cd icenine_py && uv run python benchmarks/validate_cost_function.py
+"""
+
+import math
+import os
+from pathlib import Path
+
+import numpy as np
+import torch
+
+# Change to example directory (configs use relative paths)
+project_root = Path(__file__).parent.parent.parent
+example_dir = project_root / "Examples" / "Example2.ThreeVoxels"
+os.chdir(example_dir)
+
+from icenine.config_file import ConfigFile
+from icenine.cost_functions import (
+    OverlapInfo,
+    VoxelCostFunction,
+    calculate_diffraction_overlap,
+    count_qualified_peaks,
+)
+from icenine.diffraction_core import (
+    get_scattering_omegas_torch,
+    build_reflected_ray,
+    get_illuminated_pixel,
+)
+from icenine.experiment_setup import XDMExperimentSetup
+from icenine.experimental_data import ExperimentalData
+from icenine.mic_file import MicFile
+from icenine.reconstructor import _get_voxel_vertices
+from icenine.sample import Sample
+from icenine.simulation import Simulation
+
+# =============================================================================
+# Setup — IDENTICAL to C++ CostFunctionBenchmark
+# =============================================================================
+
+print("=== IceNine Python Cost Function Validation ===")
+print("  (Matching C++ CostFunctionBenchmark configuration)")
+print()
+
+print("--- Initialization ---")
+
+# Use SAME config as C++ benchmark
+config_path = example_dir / "ConfigFiles" / "ReconstructBenchmark.config"
+config = ConfigFile.from_file(str(config_path))
+
+# The config has InfileBasename = "ScatteringData/3Grains.sim"
+# We need to read from the SAME directory as C++
+config.out_file_basename = "3Grains.sim"
+
+exp_setup = XDMExperimentSetup(config)
+exp_setup.initialize_experiment()
+detector_list = exp_setup.get_detector_list()
+range_map = exp_setup.get_range_to_index_map()
+
+sample = Sample()
+exp_setup.initialize_sample(sample, detector_list[0])
+simulator = Simulation(exp_setup)
+structure_list = sample.get_structure_list()
+
+# Read from SAME scattering data directory as C++
+exp_data = ExperimentalData.from_image_directory(
+    directory=str(example_dir / "ScatteringData"),
+    basename="3Grains.sim",
+    ext="d",
+    serial_length=5,
+    n_omega=180,
+    n_detectors=2,
+    num_rows=2048,
+    num_cols=2048,
+)
+
+# MaxQ=8 from config, eta_limit=86° from config (converted to radians)
+MAX_Q = 8.0
+eta_limit = config.eta_limit  # parsed as radians from "EtaLimit 86"
+
+print(f"  Config: {config_path.name}")
+print(f"  Data dir: ScatteringData/ (same as C++)")
+print(f"  MaxQ: {MAX_Q}")
+print(f"  eta_limit: {eta_limit:.6f} rad ({math.degrees(eta_limit):.1f}°)")
+print(f"  Detectors: {len(detector_list)}")
+
+cost_fn = VoxelCostFunction(
+    simulator=simulator,
+    detector_list=detector_list,
+    range_map=range_map,
+    exp_data=exp_data,
+    sample=sample,
+    structure_list=structure_list,
+    mode="hard",
+    max_q=MAX_Q,
+    eta_limit=eta_limit,
+)
+
+# Load ground truth voxel 2
+mic = MicFile.read(str(example_dir / "SimInput" / "three_voxels.mic"))
+voxel = mic.voxels[2]
+vertices = _get_voxel_vertices(voxel)
+orientation = voxel.orientation
+phase_index = voxel.phase
+
+print(f"  Using voxel 2, phase={phase_index}")
+print(f"  Voxel center: ({voxel.position[0]:.6f}, {voxel.position[1]:.7f}, {voxel.position[2]})")
+print(f"  Orientation matrix:")
+for r in range(3):
+    print(f"    [{orientation[r, 0]:>10.5f}{orientation[r, 1]:>10.5f}{orientation[r, 2]:>10.5f} ]")
+
+g_hkl_batch, g_mag_batch = cost_fn._phase_recip_vecs[phase_index]
+print(f"  Reciprocal vectors: {len(g_hkl_batch)}")
+print()
+
+# =============================================================================
+# Full VoxelCostFunction.evaluate() — aggregate result
+# =============================================================================
+
+print("--- Full VoxelCostFunction.evaluate() ---")
+
+result = cost_fn.evaluate(
+    orientation=orientation,
+    voxel_vertices=vertices,
+    phase_index=phase_index,
+)
+
+print(f"  quality={result.quality:.6f}  cost={result.cost:.6f}  hit_ratio={result.hit_ratio:.6f}")
+print(f"  Pixels: overlap={result.pixel_overlap}  on_det={result.pixel_on_detector}")
+print(f"  Peaks: overlap={result.peak_overlap}  on_det={result.peak_on_detector}")
+print(f"  n_quality_points={result.n_quality_points}")
+print()
+
+# =============================================================================
+# Per-peak diagnostic — compute observable peaks then evaluate each individually
+# =============================================================================
+
+print("--- Per-Peak Diagnostics ---")
+
+orientation_t = torch.from_numpy(orientation).float()
+g_lab_batch = (orientation_t @ g_hkl_batch.T).T
+
+bragg_result = get_scattering_omegas_torch(
+    g_lab_batch, g_mag_batch,
+    simulator.beam_energy, simulator.beam_deflection_chi,
+)
+
+# Collect observable peaks (same logic as VoxelCostFunction.evaluate)
+peak_omegas = []
+peak_normals = []
+
+obs_mask = bragg_result.observable
+obs_indices = torch.where(obs_mask)[0].tolist()
+beam_dir = simulator.beam_direction
+base_rot = sample.sample_to_lab_matrix[:3, :3]
+
+for idx in obs_indices:
+    g_vec = g_lab_batch[idx]
+    g_mag = torch.norm(g_vec)
+    normal = g_vec / g_mag
+
+    for omega_val in [bragg_result.omega1[idx].item(), bragg_result.omega2[idx].item()]:
+        cos_w = math.cos(omega_val)
+        sin_w = math.sin(omega_val)
+        rz = torch.tensor(
+            [[cos_w, -sin_w, 0], [sin_w, cos_w, 0], [0, 0, 1]],
+            dtype=torch.float32,
+        )
+        rot = rz @ base_rot
+        lab_normal = rot @ normal
+        reflected = beam_dir - 2.0 * torch.dot(beam_dir, lab_normal) * lab_normal
+
+        rd_norm = torch.norm(reflected)
+        if rd_norm > 0:
+            ry = abs(reflected[1].item()) / rd_norm.item()
+            rz_val = abs(reflected[2].item()) / rd_norm.item()
+            eta = math.atan2(ry, rz_val)
+            if eta >= eta_limit:
+                continue
+
+        peak_omegas.append(omega_val)
+        peak_normals.append(normal)
+
+print(f"  Observable peaks (after eta filter): {len(peak_omegas)}")
+print()
+
+# Evaluate each peak individually
+print(f"  {'Peak':>4s}  {'omega_deg':>10s}  {'pix_ovlp':>8s}  {'pix_det':>8s}  "
+      f"{'pk_ovlp':>7s}  {'pk_det':>6s}  {'n_det_ovlp':>10s}  {'quality_i':>10s}")
+print(f"  {'----':>4s}  {'----------':>10s}  {'--------':>8s}  {'--------':>8s}  "
+      f"{'-------':>7s}  {'------':>6s}  {'----------':>10s}  {'----------':>10s}")
+
+for p_idx in range(len(peak_omegas)):
+    single_omega = [peak_omegas[p_idx]]
+    single_normal = [peak_normals[p_idx]]
+
+    info = calculate_diffraction_overlap(
+        sample=sample,
+        voxel_vertices=vertices,
+        peak_omegas=single_omega,
+        peak_normals=single_normal,
+        detector_list=detector_list,
+        range_map=range_map,
+        exp_data=exp_data,
+        beam_direction=beam_dir,
+        mode="hard",
+    )
+
+    omega_deg = math.degrees(peak_omegas[p_idx])
+
+    # Compute per-peak quality contribution
+    if info.pixel_on_detector > 0 and info.n_quality_points > 0:
+        quality_i = info.quality
+    else:
+        quality_i = -1.0  # not counted
+
+    print(f"  {p_idx:>4d}  {omega_deg:>10.4f}  {info.pixel_overlap:>8d}  {info.pixel_on_detector:>8d}  "
+          f"{info.peak_overlap:>7d}  {info.peak_on_detector:>6d}  {info.n_quality_points:>10d}  "
+          f"{quality_i:>10.6f}")
+
+print()
+
+# Recompute aggregate quality from per-peak data to verify
+print("--- Aggregate Quality Recomputation ---")
+running_quality = 0.0
+n_points = 0
+for p_idx in range(len(peak_omegas)):
+    single_omega = [peak_omegas[p_idx]]
+    single_normal = [peak_normals[p_idx]]
+
+    info = calculate_diffraction_overlap(
+        sample=sample,
+        voxel_vertices=vertices,
+        peak_omegas=single_omega,
+        peak_normals=single_normal,
+        detector_list=detector_list,
+        range_map=range_map,
+        exp_data=exp_data,
+        beam_direction=beam_dir,
+        mode="hard",
+    )
+
+    if info.pixel_on_detector > 0:
+        n_det = len(detector_list)
+        if info.n_quality_points > 0:
+            # The single-peak info.quality already has the correct per-peak quality
+            cur_quality = info.quality
+        else:
+            cur_quality = 0.0
+        running_quality += (cur_quality - running_quality) / (n_points + 1)
+        n_points += 1
+
+print(f"  Recomputed quality: {running_quality:.6f}  (n_points={n_points})")
+print(f"  VoxelCostFunction quality: {result.quality:.6f}  (n_points={result.n_quality_points})")
+print()
+print("=== Validation Complete ===")


### PR DESCRIPTION
## Summary
- Add `Src/CostFunctionBenchmark.cpp` — standalone C++ per-operation benchmark with per-peak diagnostics
- Add `icenine_py/benchmarks/validate_cost_function.py` — Python validation script for apples-to-apples C++ comparison
- Add `CMakeLists.txt` CostFunctionBenchmark build target
- Document cost function C++/Python equivalence review, Q-max behavior, angular sharpness, and validation results in MIGRATION_HISTORY.md
- Add CLAUDE.md gotchas for Q-max mismatch and cost function angular sharpness

Cherry-picked from unmerged local commits on the now-deleted `feature/validate-reconstruction` branch, with MIGRATION_HISTORY conflicts resolved (dropped superseded sections, kept unique content).

## Test plan
- [x] All 329 tests pass, 34 skipped
- [x] No functional changes to production code — only adds benchmark tools and documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)