### PR TITLE
Add adaptive BFS reconstruction

### DIFF
--- a/icenine_py/MIGRATION_HISTORY.md
+++ b/icenine_py/MIGRATION_HISTORY.md
@@ -418,3 +418,44 @@ Apples-to-apples comparison using identical config (`ReconstructBenchmark.config
 3. **Different config file**: C++ benchmark used `ReconstructBenchmark.config` (MaxQ=8), Python used `Example2.Simulation.config` (MaxQ=16, but overridden by `max_q=8.0`).
 
 **Remaining 0.006 quality difference**: A single peak at omega=-61.23° rasterizes 3 pixels in Python vs 2 in C++. One pixel sits on the triangle edge — borderline rounding in ray-plane intersection. This is within acceptable tolerance and does not indicate a formula bug.
+
+### Adaptive BFS Reconstruction (2026-03-22 to 2026-03-23)
+
+Ported the production C++ reconstruction pipeline to Python:
+
+**Components ported:**
+
+| C++ Source | Python Target | Description |
+|-----------|---------------|-------------|
+| `OrientationSearch.cpp:142-198` | `MCOptimizer._zero_temp_with_variance()` | Welford variance MC |
+| `OrientationSearch.cpp:206-287` | `MCOptimizer.variance_minimizing_optimize()` | Adaptive sampling MC |
+| `DiscreteAdaptive.tmpl.cpp:108-250` | `AdaptiveVoxelReconstructor.reconstruct_voxel()` | Multi-level adaptive search |
+| `DiscreteAdaptive.tmpl.cpp:280-317` | `AdaptiveVoxelReconstructor.local_optimization()` | MC-only path for BFS neighbors |
+| `BreadthFirstReconstructor.tmpl.cpp:112-188` | `BFSReconstruction._fit_from_seed()` | BFS spatial propagation |
+| `ReconstructionStrategies.tmpl.cpp:334-356` | `BFSReconstruction._insert_seed()` | Orientation propagation to neighbors |
+| `ReconstructionStrategies.h:257-263` | `ReconstructionState` | Voxel state machine |
+
+**Key algorithm differences from BasicVoxelReconstructor:**
+
+| Feature | Basic | Adaptive + BFS |
+|---------|-------|----------------|
+| FZ candidates between levels | Full FZ every level | Top 1/4 narrow between levels |
+| Search diameter | Fixed | Shrinks ÷1.5 each level |
+| nQMax | Fixed from config | Starts at 5 + min_level, increments |
+| Quick MC | 20 steps, 0 restarts | 10 steps, 5 restarts |
+| Final optimization | Full MC only | FindOptimal + VarianceMinimizing (σ²=0.02²) |
+| Neighbor voxels | Independent full search | MC-only local_optimization from propagated orientation |
+| Spatial propagation | None | BFS queue with 90% quality threshold |
+
+**ThreeVoxels BFS benchmark:**
+
+| Metric | Serial (Basic) | BFS (Adaptive) |
+|--------|---------------|----------------|
+| Seed voxels | 3 (all independent) | 2 (voxels 1, 2) |
+| BFS neighbors | 0 | 1 (voxel 0, MC-only, 0.9s) |
+| Total time | ~6638s | 252s |
+| Speedup | 1× | ~26× |
+
+Per-seed timing: 105s (voxel 2), 147s (voxel 1). The BFS benefit scales with sample size — for interior voxels in large samples (24K+), most get the cheap MC-only path (~1s each vs ~2200s for full search).
+
+**Not yet ported**: C++ `Refit()` / `RESTART_FIT` — second-pass retry of REFIT voxels with LocalOptimization followed by full search if quality is still low.

--- a/icenine_py/README.md
+++ b/icenine_py/README.md
@@ -72,7 +72,7 @@ For each voxel in the sample:
 | `symmetry.py` | Crystal symmetry operations (pymatgen wrapper) |
 | `constants.py` | Physical constants |
 | `file_io.py` | Detector file, crystal structure file, and omega file I/O |
-| `reconstructor.py` | Serial reconstruction orchestrator — multi-level adaptive search |
+| `reconstructor.py` | Reconstruction orchestrators — serial, adaptive, and BFS spatial propagation |
 | `orientation_search.py` | Discrete grid search + zero-temperature MC optimization |
 | `cost_functions.py` | Overlap computation between simulated projections and experimental data (batched Stages A-C + sequential Stage D) |
 | `_rasterize.c` | CPython C extension for fast triangle rasterization and pixel overlap (Sutherland-Hodgman + Bresenham) |
@@ -149,6 +149,28 @@ For each voxel in the sample grid:
 5. **Adaptive deepening**: If not converged, refines the local grid and repeats
 
 The search is multi-level adaptive — it starts with a coarse orientation grid and progressively refines around promising candidates until the cost function converges.
+
+### BFS Reconstruction (Recommended for Large Samples)
+
+For spatially coherent microstructures, BFS reconstruction is much faster than independent per-voxel search. It does a full adaptive search on a seed voxel, then propagates the orientation to neighbors via BFS, using cheap MC-only optimization:
+
+```python
+from icenine.reconstructor import setup_reconstruction, BFSReconstruction
+
+setup = setup_reconstruction(config, exp_data=exp_data)
+recon = BFSReconstruction(setup)
+processed = recon.reconstruct_sample(output_mic="bfs_result.mic")
+```
+
+BFS algorithm:
+1. **Seed selection**: Pick next unvisited voxel (randomized order)
+2. **Full search**: `AdaptiveVoxelReconstructor.reconstruct_voxel()` on seed (~100-150s)
+3. **Propagate**: Copy seed orientation to all unvisited neighbors
+4. **BFS loop**: For each neighbor, run `local_optimization()` (MC-only, ~1s)
+5. **Accept/reject**: If neighbor quality > 90% of best, mark FITTED and propagate; else mark REFIT
+6. **Repeat**: Until all voxels visited
+
+For the ThreeVoxels test case: 252s (BFS) vs 6638s (serial) — 26× faster. The speedup is even larger for big samples where most voxels are interior neighbors.
 
 ### Key Config Parameters for Reconstruction
 

--- a/icenine_py/icenine/mic_file.py
+++ b/icenine_py/icenine/mic_file.py
@@ -29,6 +29,19 @@ from pathlib import Path
 from .geometry import euler_to_matrix, matrix_to_euler, euler_to_matrix_torch
 
 
+class ReconstructionState:
+    """
+    Voxel state machine for BFS reconstruction.
+
+    C++ Reference: ReconstructionStrategies.h:257-263 MultiStagedDetails
+    """
+
+    NOT_VISITED = -1
+    VISITED = 0
+    FITTED = 1
+    REFIT = 2
+
+
 @dataclass
 class Voxel:
     """
@@ -48,6 +61,7 @@ class Voxel:
         points_up: Triangle orientation (triangular mesh only)
         id: Unique voxel identifier
         deformation: 3x3 deformation tensor (optional, for strain)
+        reconstruction_id: BFS state (-1=NOT_VISITED, 0=VISITED, 1=FITTED, 2=REFIT)
     """
 
     position: np.ndarray  # (3,) - x, y, z
@@ -61,6 +75,7 @@ class Voxel:
     points_up: bool = True
     id: int = -1
     deformation: Optional[np.ndarray] = None  # (3, 3) optional
+    reconstruction_id: int = -1  # BFS state, see ReconstructionState
 
     def __post_init__(self):
         """Validate voxel data after initialization."""

--- a/icenine_py/icenine/orientation_search.py
+++ b/icenine_py/icenine/orientation_search.py
@@ -291,6 +291,172 @@ class MCOptimizer:
             overlap_info=best_info,
         )
 
+    def _zero_temp_with_variance(
+        self,
+        initial_orientation: np.ndarray,
+        subregion_radius: float,
+        n_steps: int,
+    ) -> Tuple[np.ndarray, float, float, "OverlapInfo"]:
+        """
+        Run zero-temp MC within a subregion, tracking cost variance via Welford.
+
+        Args:
+            initial_orientation: Starting 3x3 rotation matrix
+            subregion_radius: Angular radius of search neighborhood (radians)
+            n_steps: Number of MC steps to run
+
+        Returns:
+            (best_orientation, best_cost, variance, best_overlap_info)
+
+        C++ Reference: OrientationSearch.cpp:142-198 ZeroTemperatureOptimizationWithVariance
+        """
+        best_q = matrix_to_quaternion(initial_orientation)
+        optimal_q = best_q.copy()
+
+        best_info = self.cost_fn.evaluate(
+            initial_orientation, self.voxel_vertices, self.phase_index
+        )
+        best_cost = best_info.cost
+        current_cost = best_cost
+
+        # Welford online variance tracking
+        n_sampled = 1
+        mean = best_cost
+        m2 = 0.0  # sum of squared deviations
+
+        radius = math.tan(subregion_radius) / math.sqrt(12.0) if subregion_radius > 0 else 0.01
+
+        for _ in range(n_steps):
+            x = self._rng.uniform(-radius, radius)
+            y = self._rng.uniform(-radius, radius)
+            z = self._rng.uniform(-radius, radius)
+
+            delta_q = self._grid_gen.get_near_identity_point(x, y, z)
+            trial_q = _quat_multiply(delta_q, optimal_q)
+            trial_mat = quaternion_to_matrix(trial_q)
+
+            trial_info = self.cost_fn.evaluate(
+                trial_mat, self.voxel_vertices, self.phase_index
+            )
+            trial_cost = trial_info.cost
+
+            # Welford update (C++ OrientationSearch.cpp:185-187)
+            n_sampled += 1
+            delta = trial_cost - mean
+            mean = mean + delta / n_sampled
+            m2 += delta * (trial_cost - mean)
+
+            if trial_cost < current_cost:
+                current_cost = trial_cost
+                optimal_q = trial_q.copy()
+                if trial_cost < best_cost:
+                    best_cost = trial_cost
+                    best_q = optimal_q.copy()
+                    best_info = trial_info
+
+        variance = m2 / (n_sampled - 1) if n_sampled > 1 else -1.0
+        return quaternion_to_matrix(best_q), best_cost, variance, best_info
+
+    def variance_minimizing_optimize(
+        self,
+        initial_orientation: np.ndarray,
+        search_box_side: float,
+        max_mc_steps: int,
+        successive_restarts: int,
+        max_convergence_cost: float,
+        convergence_variance: float,
+        cost_fn_angular_resolution: float = math.radians(0.5),
+    ) -> SearchCandidate:
+        """
+        Adaptive sampling MC with variance-based convergence.
+
+        Uses adaptive subregion radius: shrinks on improvement, expands on failure.
+        Each subregion runs zero-temp MC with Welford variance tracking.
+        Budget extends dynamically if variance indicates rough landscape.
+
+        Args:
+            initial_orientation: Starting 3x3 rotation matrix
+            search_box_side: Side length of search region (radians)
+            max_mc_steps: Maximum total MC steps budget
+            successive_restarts: Max random restarts
+            max_convergence_cost: Cost threshold for convergence
+            convergence_variance: Variance threshold for convergence
+            cost_fn_angular_resolution: Angular resolution for step count calc
+                                        (default 0.5 degrees, hardcoded in C++)
+
+        Returns:
+            Best SearchCandidate found
+
+        C++ Reference: OrientationSearch.cpp:206-287 AdaptiveSamplingZeroTemp
+        """
+        # Initialize
+        global_best_q = matrix_to_quaternion(initial_orientation)
+        current_q = global_best_q.copy()
+        global_best_info = self.cost_fn.evaluate(
+            initial_orientation, self.voxel_vertices, self.phase_index
+        )
+        global_min_cost = global_best_info.cost
+
+        # C++: SubregionRadius = tan(search_box_side) / sqrt(48)
+        subregion_radius = math.tan(search_box_side) / math.sqrt(48.0)
+        total_steps_taken = 0
+        max_steps = max_mc_steps
+        n_global_restarts = 0
+
+        while total_steps_taken < max_steps:
+            # Adaptive step count per subregion: ceil(radius/resolution)^2.7
+            # C++ OrientationSearch.cpp:227-228
+            if cost_fn_angular_resolution > 0:
+                n_subregion_steps = int(
+                    math.ceil(subregion_radius / cost_fn_angular_resolution) ** 2.7
+                )
+            else:
+                n_subregion_steps = 10
+            n_subregion_steps = max(n_subregion_steps, 10)
+
+            # Run zero-temp MC with variance tracking in subregion
+            current_mat = quaternion_to_matrix(current_q)
+            new_orient, new_cost, variance, new_info = self._zero_temp_with_variance(
+                current_mat, subregion_radius, n_subregion_steps
+            )
+
+            # Extend budget if landscape is rough
+            if variance > convergence_variance:
+                max_steps += n_subregion_steps
+
+            total_steps_taken += n_subregion_steps
+
+            # Decision: did we improve?
+            if new_cost >= global_min_cost:
+                # No improvement — expand and restart
+                subregion_radius = min(2.0 * subregion_radius, search_box_side)
+                # Random restart from global best
+                half_box = search_box_side / 2.0
+                rx = self._rng.uniform(-half_box, half_box)
+                ry = self._rng.uniform(-half_box, half_box)
+                rz = self._rng.uniform(-half_box, half_box)
+                restart_q = self._grid_gen.get_near_identity_point(rx, ry, rz)
+                current_q = _quat_multiply(restart_q, global_best_q)
+                n_global_restarts += 1
+            else:
+                # Improvement — update global best and shrink
+                global_min_cost = new_cost
+                global_best_q = matrix_to_quaternion(new_orient)
+                global_best_info = new_info
+                current_q = global_best_q.copy()
+                subregion_radius *= 0.5
+
+            # Convergence check: cost AND variance both below threshold
+            if (global_min_cost < max_convergence_cost and
+                    abs(variance) < convergence_variance):
+                break
+
+        return SearchCandidate(
+            orientation=quaternion_to_matrix(global_best_q),
+            cost=global_min_cost,
+            overlap_info=global_best_info,
+        )
+
 
 # ---------------------------------------------------------------------------
 # Convergence checks

--- a/icenine_py/icenine/reconstructor.py
+++ b/icenine_py/icenine/reconstructor.py
@@ -12,6 +12,7 @@ C++ Reference:
 
 import math
 import time
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional
@@ -26,7 +27,7 @@ from .detector import Detector
 from .experiment_setup import XDMExperimentSetup
 from .experimental_data import ExperimentalData
 from .forward_simulation import ForwardSimulation
-from .mic_file import MicFile
+from .mic_file import MicFile, ReconstructionState
 from .orientation_search import (
     MCOptimizer,
     SearchCandidate,
@@ -678,6 +679,264 @@ class AdaptiveVoxelReconstructor:
         result.cost = final_info.cost
 
         return result
+
+
+# ---------------------------------------------------------------------------
+# BFSReconstruction — breadth-first spatial propagation
+# ---------------------------------------------------------------------------
+
+class BFSReconstruction:
+    """
+    Breadth-first reconstruction with spatial orientation propagation.
+
+    Full adaptive search on seed voxels, then MC-only local optimization
+    on neighbors using inherited orientations. This is much faster than
+    independent per-voxel search for spatially coherent microstructures.
+
+    Algorithm:
+    1. Shuffle all voxels (randomized seed order)
+    2. Pick next unvisited voxel as seed
+    3. Full AdaptiveVoxelReconstructor.reconstruct_voxel() on seed
+    4. If seed quality >= threshold: mark FITTED, propagate to neighbors via BFS
+    5. BFS loop: pop neighbor, run local_optimization (MC-only),
+       accept if (hit_ratio / best_hit_ratio) > 0.9
+    6. Repeat from step 2 until all voxels visited
+
+    C++ Reference:
+        BreadthFirstReconstructor.tmpl.cpp:112-188 Fit()
+        ReconstructionStrategies.tmpl.cpp:334-356 InsertSeed()
+    """
+
+    def __init__(self, setup: ReconstructionSetup):
+        self.setup = setup
+        self.reconstructor = AdaptiveVoxelReconstructor(setup)
+
+    def reconstruct_sample(
+        self,
+        output_mic: Optional[str] = None,
+        max_voxels: Optional[int] = None,
+        rng: Optional[np.random.Generator] = None,
+    ) -> List[int]:
+        """
+        Reconstruct all voxels using BFS propagation.
+
+        Args:
+            output_mic: Path to save reconstructed .mic file (optional)
+            max_voxels: Limit number of voxels to process (for testing)
+            rng: Random number generator
+
+        Returns:
+            List of voxel indices in order they were processed
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+
+        mic = self.setup.sample.get_mic()
+        n_total = len(mic.voxels)
+        n_process = min(n_total, max_voxels) if max_voxels else n_total
+
+        # Initialize all voxels to NOT_VISITED
+        # C++ ReconstructionStrategies.tmpl.cpp:57
+        for v in mic.voxels:
+            v.reconstruction_id = ReconstructionState.NOT_VISITED
+
+        # Randomized seed order (C++ uses random_shuffle)
+        voxel_order = list(range(n_process))
+        rng.shuffle(voxel_order)
+
+        print(f"BFS Reconstruction: {n_process} voxels", flush=True)
+        start_time = time.time()
+        all_processed = []
+        n_seeds = 0
+        n_fitted = 0
+        n_refit = 0
+
+        for seed_idx in voxel_order:
+            if mic.voxels[seed_idx].reconstruction_id != ReconstructionState.NOT_VISITED:
+                continue
+
+            n_seeds += 1
+            t_seed = time.time()
+            print(f"\n  Seed #{n_seeds}: voxel {seed_idx}", flush=True)
+
+            processed = self._fit_from_seed(mic, seed_idx, rng)
+            all_processed.extend(processed)
+
+            seed_fitted = sum(
+                1 for i in processed
+                if mic.voxels[i].reconstruction_id == ReconstructionState.FITTED
+            )
+            seed_refit = len(processed) - seed_fitted
+            n_fitted += seed_fitted
+            n_refit += seed_refit
+
+            t_elapsed = time.time() - t_seed
+            print(f"  Seed #{n_seeds} done: {len(processed)} voxels "
+                  f"({seed_fitted} fitted, {seed_refit} refit) in {t_elapsed:.1f}s",
+                  flush=True)
+
+        total_time = time.time() - start_time
+        print(f"\nBFS complete: {n_seeds} seeds, {n_fitted} fitted, "
+              f"{n_refit} refit, {total_time:.1f}s total", flush=True)
+
+        # Save output .mic file
+        if output_mic is not None:
+            mic.write(output_mic)
+            print(f"Saved reconstructed mic to {output_mic}", flush=True)
+
+        return all_processed
+
+    def _fit_from_seed(
+        self,
+        mic: MicFile,
+        seed_idx: int,
+        rng: np.random.Generator,
+    ) -> List[int]:
+        """
+        Full reconstruction on seed, then BFS propagation to neighbors.
+
+        C++ Reference: BreadthFirstReconstructor.tmpl.cpp:112-188 Fit()
+        """
+        voxel = mic.voxels[seed_idx]
+        vertices = _get_voxel_vertices(voxel)
+
+        # Full adaptive reconstruction on seed
+        t0 = time.time()
+        result = self.reconstructor.reconstruct_voxel(
+            voxel_vertices=vertices,
+            phase_index=voxel.phase,
+            rng=rng,
+        )
+        t_recon = time.time() - t0
+
+        # Evaluate overlap
+        # C++ BreadthFirstReconstructor.tmpl.cpp:136
+        overlap_info = self.reconstructor.evaluate_overlap(
+            result.orientation, vertices, voxel.phase
+        )
+
+        # Compute confidence and hit_ratio
+        # C++ CostFunctions.cpp: GetConfidence = peak_overlap / peak_on_detector
+        # C++ CostFunctions.cpp: GetHitRatio = pixel_overlap / pixel_on_detector
+        confidence = (overlap_info.peak_overlap / overlap_info.peak_on_detector
+                      if overlap_info.peak_on_detector > 0 else 0.0)
+        hit_ratio = (overlap_info.pixel_overlap / overlap_info.pixel_on_detector
+                     if overlap_info.pixel_on_detector > 0 else 0.0)
+
+        # Update seed voxel
+        voxel.orientation = result.orientation
+        voxel.cost = result.cost
+        voxel.confidence = confidence
+        voxel.overlap_ratio = hit_ratio
+
+        print(f"    Seed voxel {seed_idx}: cost={result.cost:.4f}, "
+              f"hit_ratio={hit_ratio:.3f}, conf={confidence:.3f} ({t_recon:.1f}s)",
+              flush=True)
+
+        # Check acceptance threshold
+        # C++ BreadthFirstReconstructor.tmpl.cpp:142-149
+        min_accel = self.setup.config.min_acceleration_threshold
+        if hit_ratio < min_accel:
+            voxel.reconstruction_id = ReconstructionState.REFIT
+            print(f"    Seed rejected (hit_ratio {hit_ratio:.3f} < "
+                  f"threshold {min_accel:.3f})", flush=True)
+            return [seed_idx]
+
+        # Mark fitted, start BFS
+        # C++ BreadthFirstReconstructor.tmpl.cpp:153-156
+        voxel.reconstruction_id = ReconstructionState.FITTED
+        solution = [seed_idx]
+
+        bfs_queue: deque[int] = deque()
+        self._insert_seed(mic, seed_idx, bfs_queue)
+
+        best_conf = hit_ratio
+        n_bfs = 0
+
+        # BFS expansion loop
+        # C++ BreadthFirstReconstructor.tmpl.cpp:157-184
+        while bfs_queue:
+            neighbor_idx = bfs_queue.popleft()
+
+            # Skip already-fitted voxels (C++ Pop() skips FITTED)
+            if mic.voxels[neighbor_idx].reconstruction_id == ReconstructionState.FITTED:
+                continue
+
+            neighbor = mic.voxels[neighbor_idx]
+            n_vertices = _get_voxel_vertices(neighbor)
+            n_bfs += 1
+
+            # MC-only optimization from inherited orientation
+            t_local = time.time()
+            opt_result = self.reconstructor.local_optimization(
+                voxel_vertices=n_vertices,
+                phase_index=neighbor.phase,
+                initial_orientation=neighbor.orientation,
+                rng=rng,
+            )
+            t_local_elapsed = time.time() - t_local
+
+            # Compute hit_ratio from result
+            n_info = opt_result.overlap_info
+            n_hit_ratio = (n_info.pixel_overlap / n_info.pixel_on_detector
+                           if n_info and n_info.pixel_on_detector > 0 else 0.0)
+            n_confidence = (n_info.peak_overlap / n_info.peak_on_detector
+                            if n_info and n_info.peak_on_detector > 0 else 0.0)
+
+            # Update neighbor voxel
+            neighbor.orientation = opt_result.orientation
+            neighbor.cost = opt_result.cost
+            neighbor.confidence = n_confidence
+            neighbor.overlap_ratio = n_hit_ratio
+
+            # Track best quality
+            # C++ BreadthFirstReconstructor.tmpl.cpp:162
+            best_conf = max(n_hit_ratio, best_conf)
+
+            # Acceptance check: 90% of best quality
+            # C++ BreadthFirstReconstructor.tmpl.cpp:163
+            if best_conf > 0 and (n_hit_ratio / best_conf) > 0.9:
+                # Accept: mark fitted, propagate to neighbors
+                neighbor.reconstruction_id = ReconstructionState.FITTED
+                solution.append(neighbor_idx)
+                self._insert_seed(mic, neighbor_idx, bfs_queue)
+                print(f"    BFS #{n_bfs} voxel {neighbor_idx}: FITTED "
+                      f"cost={opt_result.cost:.4f}, hit_ratio={n_hit_ratio:.3f} "
+                      f"({t_local_elapsed:.1f}s)", flush=True)
+            else:
+                # Reject: mark for later re-fitting
+                neighbor.reconstruction_id = ReconstructionState.REFIT
+                solution.append(neighbor_idx)
+                print(f"    BFS #{n_bfs} voxel {neighbor_idx}: REFIT "
+                      f"cost={opt_result.cost:.4f}, hit_ratio={n_hit_ratio:.3f} "
+                      f"(ratio={n_hit_ratio / best_conf:.3f} < 0.9) "
+                      f"({t_local_elapsed:.1f}s)", flush=True)
+
+        return solution
+
+    def _insert_seed(
+        self,
+        mic: MicFile,
+        voxel_idx: int,
+        queue: deque,
+    ) -> None:
+        """
+        Propagate orientation to unvisited neighbors and add to BFS queue.
+
+        C++ Reference: ReconstructionStrategies.tmpl.cpp:334-356 InsertSeed()
+        """
+        voxel = mic.voxels[voxel_idx]
+        # C++ uses GetNeighbors with the solution grid
+        # Python uses KDTree-based neighbor lookup with 2x side_length radius
+        radius = 2.0 * voxel.side_length
+        neighbors = mic.get_neighbors(voxel_idx, radius=radius)
+
+        for n_idx in neighbors:
+            neighbor = mic.voxels[n_idx]
+            if neighbor.reconstruction_id == ReconstructionState.NOT_VISITED:
+                neighbor.reconstruction_id = ReconstructionState.VISITED
+                neighbor.orientation = voxel.orientation.copy()  # PROPAGATION
+                queue.append(n_idx)
 
 
 # ---------------------------------------------------------------------------

--- a/icenine_py/icenine/reconstructor.py
+++ b/icenine_py/icenine/reconstructor.py
@@ -37,6 +37,7 @@ from .orientation_search import (
 from .sample import Sample
 from .sampling import (
     generate_local_grid,
+    generate_local_grid_multi_level,
     load_fundamental_zone_file,
     matrix_to_quaternion,
     quaternion_to_matrix,
@@ -322,6 +323,361 @@ class BasicVoxelReconstructor:
                 break
 
         return best_candidate
+
+
+# ---------------------------------------------------------------------------
+# AdaptiveVoxelReconstructor — single voxel, adaptive narrowing
+# ---------------------------------------------------------------------------
+
+class AdaptiveVoxelReconstructor:
+    """
+    Reconstruct a single voxel's crystal orientation using adaptive refinement.
+
+    Multi-level adaptive search with candidate narrowing:
+    1. For each resolution level:
+       a. Generate local grid at fixed resolution (levels 0-1) with shrinking diameter
+       b. Discrete search: FZ candidates × local grid (global cost fn, pixel_radius=3)
+       c. Re-evaluate candidates with local cost fn (pixel_radius=0)
+       d. Quick MC (10 steps, 5 restarts) on all candidates
+       e. Sort, keep top 1/4 as FZ candidates for next level
+       f. Shrink diameter by ÷1.5, increment nQMax
+    2. After all levels:
+       a. FindOptimal: full MC on top candidates with convergence check
+       b. VarianceMinimizing: refine best until variance < 0.02²
+       c. Final overlap evaluation
+
+    C++ Reference: Src/DiscreteAdaptive.tmpl.cpp:108-250 ReconstructVoxel
+    """
+
+    def __init__(self, setup: ReconstructionSetup):
+        self.setup = setup
+        self.params = setup.search_params
+
+    def reconstruct_voxel(
+        self,
+        voxel_vertices: torch.Tensor,
+        phase_index: int = 0,
+        rng: Optional[np.random.Generator] = None,
+    ) -> SearchCandidate:
+        """
+        Reconstruct orientation for a single voxel using adaptive refinement.
+
+        Args:
+            voxel_vertices: Triangle vertices in sample frame, shape (3, 3)
+            phase_index: Crystal phase index
+            rng: Random number generator for MC optimization
+
+        Returns:
+            Best SearchCandidate found
+
+        C++ Reference: DiscreteAdaptive.tmpl.cpp:108-250
+        """
+        eta_limit = self.setup.exp_setup.get_eta_limit()
+
+        # Local cost function (pixel_radius=0) for MC and re-evaluation
+        # C++ Reference: DiscreteAdaptive.tmpl.cpp:120-121 LocalSearchCostFunctions
+        local_cost_fn = VoxelCostFunction(
+            simulator=self.setup.simulator,
+            detector_list=self.setup.detector_list,
+            range_map=self.setup.range_map,
+            exp_data=self.setup.exp_data,
+            sample=self.setup.sample,
+            structure_list=self.setup.structure_list,
+            mode='hard',
+            eta_limit=eta_limit,
+            pixel_radius=0,
+        )
+
+        # MC optimizer uses local cost function
+        mc_optimizer = MCOptimizer(
+            cost_fn=local_cost_fn,
+            voxel_vertices=voxel_vertices,
+            phase_index=phase_index,
+            rng=rng,
+        )
+
+        # Initialize search state
+        # C++ DiscreteAdaptive.tmpl.cpp:139-141
+        fz_orientations = self.setup.fz_orientations  # full FZ set initially
+        diameter = self.params.local_grid_radius
+        n_q_max = 5.0 + self.params.min_local_resolution
+
+        candidates = []
+
+        for level in range(self.params.max_local_resolution + 1):
+            t_level = time.time()
+
+            # Generate local grid: always levels 0-1 with current diameter
+            # C++ DiscreteAdaptive.tmpl.cpp:149
+            local_grid = generate_local_grid_multi_level(diameter, 0, 1)
+
+            # Global cost function with current nQMax
+            # C++ DiscreteAdaptive.tmpl.cpp:65-66 nPixelRadius=3
+            global_cost_fn = VoxelCostFunction(
+                simulator=self.setup.simulator,
+                detector_list=self.setup.detector_list,
+                range_map=self.setup.range_map,
+                exp_data=self.setup.exp_data,
+                sample=self.setup.sample,
+                structure_list=self.setup.structure_list,
+                mode='hard',
+                eta_limit=eta_limit,
+                pixel_radius=3,
+                max_q=n_q_max,
+            )
+
+            # Phase 1: Discrete search
+            n_evals = len(fz_orientations) * len(local_grid)
+            print(f"    Level {level}: discrete search "
+                  f"({len(fz_orientations)} FZ × {len(local_grid)} local "
+                  f"= {n_evals} evals, nQMax={n_q_max:.0f}, "
+                  f"diameter={math.degrees(diameter):.2f}°)", flush=True)
+
+            candidates = run_discrete_search(
+                cost_fn=global_cost_fn,
+                fz_orientations=fz_orientations,
+                local_grid=local_grid,
+                voxel_vertices=voxel_vertices,
+                phase_index=phase_index,
+            )
+            t_discrete = time.time() - t_level
+
+            # Increment nQMax for next level
+            # C++ DiscreteAdaptive.tmpl.cpp:155
+            n_q_max += 1
+
+            if not candidates:
+                print(f"    Level {level}: no candidates found ({t_discrete:.1f}s)",
+                      flush=True)
+                continue
+
+            # Phase 2: Re-evaluate candidates with local cost function (pixel_radius=0)
+            # C++ DiscreteAdaptive.tmpl.cpp:156-165
+            t_reeval = time.time()
+            for cand in candidates:
+                info = local_cost_fn.evaluate(
+                    orientation=cand.orientation,
+                    voxel_vertices=voxel_vertices,
+                    phase_index=phase_index,
+                )
+                cand.cost = info.cost
+                cand.overlap_info = info
+            candidates.sort()
+            t_reeval_elapsed = time.time() - t_reeval
+
+            print(f"    Level {level}: {len(candidates)} candidates "
+                  f"(discrete={t_discrete:.1f}s, reeval={t_reeval_elapsed:.1f}s), "
+                  f"best cost={candidates[0].cost:.4f}", flush=True)
+
+            # Phase 3: Quick MC on all candidates (10 steps, 5 restarts)
+            # C++ DiscreteAdaptive.tmpl.cpp:173-194
+            t_mc = time.time()
+            trial_radius = max(diameter / 3.0, math.radians(0.2))
+            # C++ ContinuousSearch.h:70-73 CalculateSearchParameter
+            # BoxWidth = localGridRadius / 2^localResolution
+            # For trial search: localResolution = min_local_resolution
+            trial_box_width = trial_radius / (
+                2 ** self.params.min_local_resolution
+            )
+            trial_step = trial_box_width * self.params.mc_radius_scale_factor
+
+            for cand in candidates:
+                result = mc_optimizer.optimize(
+                    initial_orientation=cand.orientation,
+                    angular_box_side=trial_box_width,
+                    angular_step=trial_step,
+                    max_mc_steps=10,
+                    max_restarts=5,
+                    max_convergence_cost=self.params.max_convergence_cost,
+                )
+                cand.orientation = result.orientation
+                cand.cost = result.cost
+                cand.overlap_info = result.overlap_info
+            t_quick = time.time() - t_mc
+
+            # Phase 4: Shrink diameter, keep top 1/4
+            # C++ DiscreteAdaptive.tmpl.cpp:196-205
+            diameter /= 1.5
+            candidates.sort()
+            n_keep = max(1, len(candidates) // 4)
+            fz_orientations = np.array([c.orientation for c in candidates[:n_keep]])
+
+            t_total = time.time() - t_level
+            print(f"    Level {level}: quick MC ({t_quick:.1f}s), "
+                  f"kept {n_keep}/{len(candidates)}, "
+                  f"best cost={candidates[0].cost:.4f}, "
+                  f"level total={t_total:.1f}s", flush=True)
+
+        # After all levels: FindOptimal + VarianceMinimizing
+        # C++ DiscreteAdaptive.tmpl.cpp:210-246
+        if not candidates:
+            return SearchCandidate(orientation=np.eye(3), cost=1.0)
+
+        final_radius = max(diameter / 3.0, math.radians(0.2))
+        final_box_width = final_radius / (2 ** self.params.min_local_resolution)
+        final_step = final_box_width * self.params.mc_radius_scale_factor
+
+        # FindOptimal: full MC on top candidates with convergence check
+        # C++ ContinuousSearch.h:316-346
+        n_final = min(
+            len(candidates), self.params.max_discrete_candidates
+        )
+        print(f"    FindOptimal: full MC on {n_final} candidates", flush=True)
+        t_final = time.time()
+
+        best_candidate = SearchCandidate(orientation=np.eye(3), cost=1.0)
+        converged = False
+        for ci, cand in enumerate(candidates[:n_final]):
+            result = mc_optimizer.optimize(
+                initial_orientation=cand.orientation,
+                angular_box_side=final_box_width,
+                angular_step=final_step,
+                max_mc_steps=self.params.max_mc_steps,
+                max_restarts=self.params.successive_restarts,
+                max_convergence_cost=self.params.max_convergence_cost,
+            )
+            if result.cost < best_candidate.cost:
+                best_candidate = result
+                # Convergence check: hit_ratio >= 1.0
+                # C++ ContinuousSearch.h:276-286 HitRatioConvergenceFn with ratio=1.0
+                if (result.overlap_info is not None and
+                        hit_ratio_converged(result.overlap_info, 1.0)):
+                    converged = True
+                    break
+        t_find = time.time() - t_final
+        print(f"    FindOptimal: {ci + 1} evaluated ({t_find:.1f}s), "
+              f"best cost={best_candidate.cost:.4f}"
+              f"{' CONVERGED' if converged else ''}", flush=True)
+
+        # VarianceMinimizing: refine best until variance < 0.02²
+        # C++ DiscreteAdaptive.tmpl.cpp:232
+        t_var = time.time()
+        var_result = mc_optimizer.variance_minimizing_optimize(
+            initial_orientation=best_candidate.orientation,
+            search_box_side=final_box_width,
+            max_mc_steps=self.params.max_mc_steps,
+            successive_restarts=self.params.successive_restarts,
+            max_convergence_cost=0.0,  # C++ sets this to 0 for final optimization
+            convergence_variance=0.02 ** 2,
+        )
+        if var_result.cost < best_candidate.cost:
+            best_candidate = var_result
+        t_var_elapsed = time.time() - t_var
+        print(f"    VarianceMin: ({t_var_elapsed:.1f}s), "
+              f"cost={best_candidate.cost:.4f}", flush=True)
+
+        # Final overlap evaluation
+        # C++ DiscreteAdaptive.tmpl.cpp:234-242
+        final_info = local_cost_fn.evaluate(
+            orientation=best_candidate.orientation,
+            voxel_vertices=voxel_vertices,
+            phase_index=phase_index,
+        )
+        best_candidate.overlap_info = final_info
+        best_candidate.cost = final_info.cost
+
+        return best_candidate
+
+    def evaluate_overlap(
+        self,
+        orientation: np.ndarray,
+        voxel_vertices: torch.Tensor,
+        phase_index: int = 0,
+    ) -> OverlapInfo:
+        """
+        Evaluate overlap info for a given orientation (for BFS acceptance checks).
+
+        C++ Reference: DiscreteAdaptive.tmpl.cpp:255-275 EvaluateOverlapInfo
+        """
+        eta_limit = self.setup.exp_setup.get_eta_limit()
+        local_cost_fn = VoxelCostFunction(
+            simulator=self.setup.simulator,
+            detector_list=self.setup.detector_list,
+            range_map=self.setup.range_map,
+            exp_data=self.setup.exp_data,
+            sample=self.setup.sample,
+            structure_list=self.setup.structure_list,
+            mode='hard',
+            eta_limit=eta_limit,
+            pixel_radius=0,
+        )
+        return local_cost_fn.evaluate(
+            orientation=orientation,
+            voxel_vertices=voxel_vertices,
+            phase_index=phase_index,
+        )
+
+    def local_optimization(
+        self,
+        voxel_vertices: torch.Tensor,
+        phase_index: int,
+        initial_orientation: np.ndarray,
+        rng: Optional[np.random.Generator] = None,
+    ) -> SearchCandidate:
+        """
+        MC-only optimization from a given starting orientation (for BFS neighbors).
+
+        Runs variance-minimizing MC without any discrete search. This is the
+        cheap path used when orientation is inherited from a fitted neighbor.
+
+        Args:
+            voxel_vertices: Triangle vertices in sample frame, shape (3, 3)
+            phase_index: Crystal phase index
+            initial_orientation: Starting 3x3 rotation matrix (from neighbor)
+            rng: Random number generator
+
+        Returns:
+            Optimized SearchCandidate
+
+        C++ Reference: DiscreteAdaptive.tmpl.cpp:280-317 LocalOptimization
+        """
+        eta_limit = self.setup.exp_setup.get_eta_limit()
+        local_cost_fn = VoxelCostFunction(
+            simulator=self.setup.simulator,
+            detector_list=self.setup.detector_list,
+            range_map=self.setup.range_map,
+            exp_data=self.setup.exp_data,
+            sample=self.setup.sample,
+            structure_list=self.setup.structure_list,
+            mode='hard',
+            eta_limit=eta_limit,
+            pixel_radius=0,
+        )
+
+        mc_optimizer = MCOptimizer(
+            cost_fn=local_cost_fn,
+            voxel_vertices=voxel_vertices,
+            phase_index=phase_index,
+            rng=rng,
+        )
+
+        # C++ ContinuousSearch.h:70-73: BoxWidth = localGridRadius / 2^localResolution
+        box_width = self.params.local_grid_radius / (
+            2 ** self.params.min_local_resolution
+        )
+
+        # Variance-minimizing MC
+        # C++ DiscreteAdaptive.tmpl.cpp:305
+        result = mc_optimizer.variance_minimizing_optimize(
+            initial_orientation=initial_orientation,
+            search_box_side=box_width,
+            max_mc_steps=self.params.max_mc_steps,
+            successive_restarts=self.params.successive_restarts,
+            max_convergence_cost=self.params.max_convergence_cost,
+            convergence_variance=0.02 ** 2,
+        )
+
+        # Final overlap evaluation
+        # C++ DiscreteAdaptive.tmpl.cpp:307-314
+        final_info = local_cost_fn.evaluate(
+            orientation=result.orientation,
+            voxel_vertices=voxel_vertices,
+            phase_index=phase_index,
+        )
+        result.overlap_info = final_info
+        result.cost = final_info.cost
+
+        return result
 
 
 # ---------------------------------------------------------------------------

--- a/icenine_py/tests/test_reconstruction_integration.py
+++ b/icenine_py/tests/test_reconstruction_integration.py
@@ -24,11 +24,13 @@ from icenine.mic_file import MicFile
 from icenine.orientation_search import MCOptimizer, SearchCandidate, run_discrete_search
 from icenine.reconstructor import (
     AdaptiveVoxelReconstructor,
+    BFSReconstruction,
     BasicVoxelReconstructor,
     ReconstructionSetup,
     _get_voxel_vertices,
     setup_reconstruction,
 )
+from icenine.mic_file import ReconstructionState
 from icenine.sample import Sample
 from icenine.sampling import (
     generate_local_grid,
@@ -442,3 +444,114 @@ class TestAdaptiveVoxelReconstructor:
             f"Expected misorientation < 5 deg from 0.5° perturbation, "
             f"got {misori_deg:.2f} deg"
         )
+
+
+# ============================================================================
+# Test: BFSReconstruction
+# ============================================================================
+
+class TestBFSReconstruction:
+    """Test BFS reconstruction with spatial propagation."""
+
+    @pytest.fixture
+    def bfs_setup(self, sim_config, exp_data, project_root):
+        """Set up BFSReconstruction."""
+        fz_file = sim_config.fundamental_zone_filename
+        if not fz_file or not Path(fz_file).exists():
+            pytest.skip(f"FZ file not found: {fz_file}")
+        fz_orientations = load_fundamental_zone_file(fz_file)
+
+        setup = setup_reconstruction(
+            sim_config, exp_data=exp_data, fz_orientations=fz_orientations,
+        )
+        return BFSReconstruction(setup), setup
+
+    def test_bfs_three_voxels(
+        self, bfs_setup, ground_truth_mic, cubic_symmetry_quats
+    ):
+        """
+        Run BFS reconstruction on ThreeVoxels sample.
+
+        Verifies:
+        - All 3 voxels get processed (FITTED or REFIT)
+        - Seed gets full reconstruction (should recover orientation)
+        - BFS neighbors use MC-only local optimization
+        - Recovered orientations are close to ground truth
+
+        C++ Reference: BreadthFirstReconstructor.tmpl.cpp:112-188
+        """
+        bfs, setup = bfs_setup
+        mic = setup.sample.get_mic()
+        n_voxels = len(mic.voxels)
+
+        processed = bfs.reconstruct_sample(
+            max_voxels=n_voxels,
+            rng=np.random.default_rng(42),
+        )
+
+        # All voxels should be processed
+        assert len(processed) == n_voxels, (
+            f"Expected {n_voxels} processed, got {len(processed)}"
+        )
+
+        # No voxel should remain NOT_VISITED
+        for i, v in enumerate(mic.voxels):
+            assert v.reconstruction_id != ReconstructionState.NOT_VISITED, (
+                f"Voxel {i} still NOT_VISITED after BFS"
+            )
+
+        # Check orientations against ground truth
+        for i in range(n_voxels):
+            v = mic.voxels[i]
+            gt = ground_truth_mic.voxels[i]
+
+            if v.reconstruction_id == ReconstructionState.FITTED:
+                q_result = matrix_to_quaternion(v.orientation)
+                q_truth = matrix_to_quaternion(gt.orientation)
+                misori = get_misorientation(
+                    q_result, q_truth, cubic_symmetry_quats
+                )
+                misori_deg = math.degrees(misori)
+
+                assert misori_deg < 10.0, (
+                    f"Fitted voxel {i}: misorientation {misori_deg:.2f}° > 10°"
+                )
+
+    def test_bfs_propagation_uses_local_optimization(
+        self, bfs_setup, ground_truth_mic
+    ):
+        """
+        Verify that BFS propagates orientation from seed to neighbors.
+
+        After InsertSeed, NOT_VISITED neighbors should become VISITED
+        with the seed's orientation copied to them.
+        """
+        bfs, setup = bfs_setup
+        mic = setup.sample.get_mic()
+
+        # Initialize state
+        for v in mic.voxels:
+            v.reconstruction_id = ReconstructionState.NOT_VISITED
+
+        # Manually test InsertSeed
+        from collections import deque
+        queue: deque[int] = deque()
+
+        # Set voxel 0 as fitted with a known orientation
+        test_orient = ground_truth_mic.voxels[0].orientation.copy()
+        mic.voxels[0].orientation = test_orient
+        mic.voxels[0].reconstruction_id = ReconstructionState.FITTED
+
+        bfs._insert_seed(mic, 0, queue)
+
+        # Check: neighbors of voxel 0 should be VISITED with propagated orientation
+        for n_idx in queue:
+            neighbor = mic.voxels[n_idx]
+            assert neighbor.reconstruction_id == ReconstructionState.VISITED, (
+                f"Neighbor {n_idx} should be VISITED after InsertSeed"
+            )
+            # Orientation should be copied from seed
+            np.testing.assert_array_equal(
+                neighbor.orientation, test_orient,
+                err_msg=f"Neighbor {n_idx} should have seed's orientation"
+            )

--- a/icenine_py/tests/test_reconstruction_integration.py
+++ b/icenine_py/tests/test_reconstruction_integration.py
@@ -312,3 +312,55 @@ class TestSingleVoxelReconstruction:
         assert misori_deg < 10.0, (
             f"Expected misorientation < 10 deg, got {misori_deg:.2f} deg"
         )
+
+    def test_variance_minimizing_mc(
+        self, recon_setup, ground_truth_mic, cubic_symmetry_quats
+    ):
+        """
+        Start from ground truth + small perturbation, run variance-minimizing
+        MC, verify convergence.
+
+        C++ Reference: OrientationSearch.cpp AdaptiveSamplingZeroTemp
+        """
+        cost_fn = recon_setup
+        voxel = ground_truth_mic.voxels[0]
+        vertices = _get_voxel_vertices(voxel)
+        gt_orientation = voxel.orientation
+
+        # Perturb by ~1 degree
+        from scipy.spatial.transform import Rotation
+        perturbation = Rotation.from_rotvec(
+            np.array([0.015, 0.005, -0.005])
+        ).as_matrix()
+        start_orientation = perturbation @ gt_orientation
+
+        mc = MCOptimizer(
+            cost_fn=cost_fn,
+            voxel_vertices=vertices,
+            phase_index=voxel.phase,
+            rng=np.random.default_rng(123),
+        )
+
+        result = mc.variance_minimizing_optimize(
+            initial_orientation=start_orientation,
+            search_box_side=math.radians(2.0),
+            max_mc_steps=200,
+            successive_restarts=2,
+            max_convergence_cost=0.1,
+            convergence_variance=0.02 ** 2,
+        )
+
+        # Should find overlap
+        assert result.cost < 1.0, (
+            f"Variance-min MC should find overlap, got cost={result.cost}"
+        )
+
+        # Should converge close to ground truth
+        q_result = matrix_to_quaternion(result.orientation)
+        q_truth = matrix_to_quaternion(gt_orientation)
+        misori = get_misorientation(q_result, q_truth, cubic_symmetry_quats)
+        misori_deg = math.degrees(misori)
+
+        assert misori_deg < 10.0, (
+            f"Expected misorientation < 10 deg, got {misori_deg:.2f} deg"
+        )

--- a/icenine_py/tests/test_reconstruction_integration.py
+++ b/icenine_py/tests/test_reconstruction_integration.py
@@ -23,6 +23,7 @@ from icenine.experimental_data import ExperimentalData
 from icenine.mic_file import MicFile
 from icenine.orientation_search import MCOptimizer, SearchCandidate, run_discrete_search
 from icenine.reconstructor import (
+    AdaptiveVoxelReconstructor,
     BasicVoxelReconstructor,
     ReconstructionSetup,
     _get_voxel_vertices,
@@ -363,4 +364,81 @@ class TestSingleVoxelReconstruction:
 
         assert misori_deg < 10.0, (
             f"Expected misorientation < 10 deg, got {misori_deg:.2f} deg"
+        )
+
+
+# ============================================================================
+# Test: AdaptiveVoxelReconstructor
+# ============================================================================
+
+class TestAdaptiveVoxelReconstructor:
+    """Test the adaptive refinement reconstructor."""
+
+    @pytest.fixture
+    def adaptive_setup(self, sim_config, exp_data, project_root):
+        """Set up AdaptiveVoxelReconstructor."""
+
+        exp_setup = XDMExperimentSetup(sim_config)
+        exp_setup.initialize_experiment()
+        detector_list = exp_setup.get_detector_list()
+        range_map = exp_setup.get_range_to_index_map()
+        sample = Sample()
+        exp_setup.initialize_sample(sample, detector_list[0])
+        simulator = Simulation(exp_setup)
+        structure_list = sample.get_structure_list()
+
+        fz_file = sim_config.fundamental_zone_filename
+        if not fz_file or not Path(fz_file).exists():
+            pytest.skip(f"FZ file not found: {fz_file}")
+        fz_orientations = load_fundamental_zone_file(fz_file)
+
+        setup = setup_reconstruction(
+            sim_config, exp_data=exp_data, fz_orientations=fz_orientations,
+        )
+        return AdaptiveVoxelReconstructor(setup)
+
+    def test_local_optimization_from_perturbation(
+        self, adaptive_setup, ground_truth_mic, cubic_symmetry_quats
+    ):
+        """
+        Start from ground truth + small perturbation, run local_optimization
+        (MC-only path), verify convergence back to ground truth.
+
+        This tests the cheap BFS neighbor path.
+
+        C++ Reference: DiscreteAdaptive.tmpl.cpp:280-317 LocalOptimization
+        """
+        reconstructor = adaptive_setup
+        voxel = ground_truth_mic.voxels[0]
+        vertices = _get_voxel_vertices(voxel)
+        gt_orientation = voxel.orientation
+
+        # Perturb by ~0.5 degrees
+        from scipy.spatial.transform import Rotation
+        perturbation = Rotation.from_rotvec(
+            np.array([0.008, 0.003, -0.003])
+        ).as_matrix()
+        start_orientation = (perturbation @ gt_orientation).astype(np.float32)
+
+        result = reconstructor.local_optimization(
+            voxel_vertices=vertices,
+            phase_index=voxel.phase,
+            initial_orientation=start_orientation,
+            rng=np.random.default_rng(42),
+        )
+
+        # Should find overlap
+        assert result.cost < 1.0, (
+            f"Local optimization should find overlap, got cost={result.cost}"
+        )
+
+        # Should converge close to ground truth
+        q_result = matrix_to_quaternion(result.orientation)
+        q_truth = matrix_to_quaternion(gt_orientation)
+        misori = get_misorientation(q_result, q_truth, cubic_symmetry_quats)
+        misori_deg = math.degrees(misori)
+
+        assert misori_deg < 5.0, (
+            f"Expected misorientation < 5 deg from 0.5° perturbation, "
+            f"got {misori_deg:.2f} deg"
         )


### PR DESCRIPTION
## Summary

- Port C++ adaptive reconstruction pipeline to Python: `AdaptiveVoxelReconstructor` (multi-level candidate narrowing, variance-minimizing MC) and `BFSReconstruction` (spatial orientation propagation)
- Add variance-minimizing MC optimization (`MCOptimizer.variance_minimizing_optimize()`) with Welford online variance tracking
- Add BFS state machine (`ReconstructionState`) and `reconstruction_id` field to `Voxel` for spatial propagation tracking

## Key changes

**`orientation_search.py`**: Added `_zero_temp_with_variance()` and `variance_minimizing_optimize()` to `MCOptimizer`

**`reconstructor.py`**: Added `AdaptiveVoxelReconstructor` (candidate narrowing between levels, shrinking diameter, nQMax incrementing, FindOptimal + VarianceMinimizing) and `BFSReconstruction` (seed → full search, neighbors → MC-only local_optimization, 90% quality threshold)

**`mic_file.py`**: Added `ReconstructionState` enum and `reconstruction_id` field to `Voxel`

## Performance

ThreeVoxels benchmark: 252s (BFS, 2 seeds + 1 MC neighbor) vs 6638s (serial) — **26× faster**

## Test plan

- [x] 324 unit tests pass (no regressions)
- [x] 9 integration tests pass (cost function, MC convergence, adaptive local optimization, BFS propagation, BFS end-to-end)
- [x] BFS InsertSeed correctly propagates orientation to unvisited neighbors
- [x] BFS end-to-end: all 3 voxels processed, fitted voxels within 10° of ground truth

🤖 Generated with [Claude Code](https://claude.com/claude-code)