### PR TITLE
Fix 5 documented bugs from migration history review

### DIFF
--- a/icenine_py/MIGRATION_HISTORY.md
+++ b/icenine_py/MIGRATION_HISTORY.md
@@ -59,11 +59,10 @@ Two bugs in detector geometry caused zero pixel overlap between Python and C++ f
 
 **Related fix in `file_io.py`**: `LabFrameOrientation` Euler angles were being double-converted from degrees to radians — `euler_to_matrix()` internally converts degrees, but the code was passing already-converted radians.
 
-### Latent Bug: Sample orientation save/restore (degree/radian mismatch)
-- `sample.get_orientation()` returns Euler angles in **radians**
-- `sample.set_orientation()` expects angles in **degrees** (it calls `passive_euler_matrix()` which converts internally)
-- C++ `SetOrientation` takes **radians** directly (calls `cosf()`)
-- This bug doesn't trigger for the Example2 test case where orientation is `(0,0,0)`, but will break for non-zero sample orientations.
+### Fixed Bug: Sample orientation save/restore (degree/radian mismatch)
+- `sample.get_orientation()` was returning Euler angles in **radians** but `sample.set_orientation()` expects **degrees**
+- `rotate()`, `rotate_axis_angle()` were not updating `orientation_euler` after composition
+- **Fix**: `orientation_euler` now stores degrees. `get_orientation()` returns degrees. `rotate()` and `rotate_axis_angle()` extract Euler angles after updating the matrix. `rotate_z()` does not update `orientation_euler` (hot-path, callers save/restore full matrix).
 
 ### Euler Angle Conventions
 - **Voxel orientations**: Active ZXZ Bunge convention (standard crystallography)
@@ -93,11 +92,16 @@ Fixed all 12 test failures and 17 test errors to achieve a clean test suite (256
 
 ## Remaining Work
 
+### Ported
+- Forward simulation (serial + batched differentiable)
+- Reconstruction: serial (BasicVoxelReconstructor), adaptive (AdaptiveVoxelReconstructor), BFS (BFSReconstruction)
+- Cost functions (batched stages A-D with C extension)
+- Search strategies: discrete grid search, zero-temperature MC, variance-minimizing MC
+
 ### Not Yet Ported
-- Reconstruction algorithms (Reconstructor, BreadthFirstReconstructor, DiscreteAdaptive)
-- Cost functions and search strategies
 - Parallel processing (MPI-based server/client)
-- Continuous optimization (ContinuousSearch)
+- Step size file reading (`_read_step_size_file` stub in `experiment_setup.py`)
+- Crystal symmetry unique reflection list filtering
 
 ### Integration Testing — Pixel-Exact Match Achieved
 
@@ -384,7 +388,7 @@ If all vertices project outside the detector image, C++ correctly leaves `bDetec
 
 **Fix**: In both serial (`calculate_diffraction_overlap`, line 316) and batched (`calculate_diffraction_overlap_batched`, line 519) paths, moved `detector_lit` assignment after the overlap computation. Set it based on `n_lit_int > 0` (triangle has in-bounds pixels, equivalent to C++ `IsInBound`) or `n_overlap_int > 0`. The `pixel_radius > 0` branch was already correct (explicitly checks bounds via `found_in_bounds`).
 
-**Note on `GetConfidence` semantics**: C++ `GetConfidence()` returns `nPeakOverlap / nPeakOnDetector` (fraction of peaks with overlap). Python `OverlapInfo.confidence` returns `quality` (Welford mean of per-peak quality contributions). The Python reconstructor uses `hit_ratio` (= `pixel_overlap / pixel_on_detector`) for convergence decisions, which is closer to the C++ `GetHitRatio()`.
+**`GetConfidence` semantics (fixed)**: Python `OverlapInfo.confidence` now correctly returns `peak_overlap / peak_on_detector`, matching C++ `GetConfidence()`. Previously it returned `quality` (Welford mean).
 
 ### Q-max Behavior Clarification
 
@@ -459,3 +463,17 @@ Ported the production C++ reconstruction pipeline to Python:
 Per-seed timing: 105s (voxel 2), 147s (voxel 1). The BFS benefit scales with sample size — for interior voxels in large samples (24K+), most get the cheap MC-only path (~1s each vs ~2200s for full search).
 
 **Not yet ported**: C++ `Refit()` / `RESTART_FIT` — second-pass retry of REFIT voxels with LocalOptimization followed by full search if quality is still low.
+
+### Bug Fix Batch (2026-03-23)
+
+Five documented bugs fixed in one pass:
+
+1. **Sample orientation degree/radian mismatch** (`sample.py`): `get_orientation()` returned radians but `set_orientation()` expects degrees — `set_orientation(*get_orientation())` silently produced wrong results. `rotate()` and `rotate_axis_angle()` didn't update `orientation_euler`. Fixed: `orientation_euler` now stores degrees, rotation methods extract Euler angles after matrix update, `rotate_z()` skips (hot-path, documented).
+
+2. **OverlapInfo.confidence semantic mismatch** (`cost_functions.py`): `confidence` property returned `quality` (Welford mean) instead of `peak_overlap / peak_on_detector` (C++ `GetConfidence`). Fixed to match C++.
+
+3. **Outdated "Remaining Work"** (`MIGRATION_HISTORY.md`): Listed reconstruction as "Not Yet Ported" despite being fully ported. Updated.
+
+4. **_read_step_size_file print warning** (`experiment_setup.py`): Changed `print()` to `warnings.warn()` for proper Python warning semantics.
+
+5. **Crystal symmetry TODO** (`experiment_setup.py`): Replaced bare TODO with explanation of why deferred (cubic symmetry doesn't need it).

--- a/icenine_py/icenine/cost_functions.py
+++ b/icenine_py/icenine/cost_functions.py
@@ -124,11 +124,14 @@ class OverlapInfo:
     @property
     def confidence(self) -> float:
         """
-        Confidence metric combining hit ratio and quality.
+        Fraction of peaks with overlap (peak-level hit ratio).
 
-        C++ Reference: CostFunctions.h GetConfidence
+        C++ Reference: CostFunctions.cpp GetConfidence
+        Returns: peak_overlap / peak_on_detector
         """
-        return self.quality
+        if self.peak_on_detector == 0:
+            return 0.0
+        return self.peak_overlap / self.peak_on_detector
 
 
 # ---------------------------------------------------------------------------

--- a/icenine_py/icenine/experiment_setup.py
+++ b/icenine_py/icenine/experiment_setup.py
@@ -13,6 +13,7 @@ The ExperimentSetup classes act as container/orchestration classes that:
 Author: S. F. Li
 """
 
+import warnings
 from dataclasses import dataclass
 from typing import List, Optional
 import numpy as np
@@ -415,9 +416,12 @@ class XDMExperimentSetup(ExperimentSetup):
         # Read as detector info (same file format)
         from .file_io import DetectorInfo
 
-        # TODO: Implement proper step size file reading
-        # For now, return empty list as these files are optional
-        print(f"WARNING: Step size file reading not yet implemented: {filename}")
+        # Step size file reading not yet implemented — these files are optional
+        # and not used by current reconstruction.
+        warnings.warn(
+            f"Step size file reading not yet implemented: {filename}",
+            stacklevel=2,
+        )
         return []
 
     def _validate_experiment_setup(self) -> None:
@@ -548,7 +552,9 @@ class XDMExperimentSetup(ExperimentSetup):
         # Apply symmetry to reflection vectors
         symmetry = self.get_sample_symmetry()
         sample.set_sample_symmetry(symmetry)
-        # TODO: crystal.set_unique_reflection_list(symmetry)
+        # Symmetry-based reflection filtering (crystal.set_unique_reflection_list)
+        # is not needed for cubic symmetry — all reflections are already equivalent.
+        # Implement if non-cubic symmetry support is added.
 
         # Add crystal structure to sample
         sample.add_crystal_structure(crystal)

--- a/icenine_py/icenine/sample.py
+++ b/icenine_py/icenine/sample.py
@@ -196,9 +196,9 @@ class Sample:
         # Update 3x3 rotation part of 4x4 matrix
         self.sample_to_lab_matrix[:3, :3] = rotation
 
-        # Store Euler angles
+        # Store Euler angles in degrees (matching set_orientation input convention)
         self.orientation_euler = torch.tensor(
-            [phi_rad, theta_rad, psi_rad], dtype=torch.float32
+            [phi, theta, psi], dtype=torch.float32
         )
 
     def set_orientation_matrix(self, rotation_matrix: np.ndarray) -> None:
@@ -213,10 +213,10 @@ class Sample:
         rotation = torch.from_numpy(rotation_matrix.astype(np.float32))
         self.sample_to_lab_matrix[:3, :3] = rotation
 
-        # Extract Euler angles from rotation matrix
+        # Extract Euler angles from rotation matrix (returns radians), store as degrees
         phi, theta, psi = matrix_to_euler(rotation.numpy())
         self.orientation_euler = torch.tensor(
-            [phi, theta, psi], dtype=torch.float32
+            [np.rad2deg(phi), np.rad2deg(theta), np.rad2deg(psi)], dtype=torch.float32
         )
 
     def rotate(self, phi: float, theta: float, psi: float) -> None:
@@ -246,9 +246,11 @@ class Sample:
         rotation_old = self.sample_to_lab_matrix[:3, :3]
         self.sample_to_lab_matrix[:3, :3] = torch.matmul(R_new, rotation_old)
 
-        # Update Euler angles (Note: extraction may not be unique due to gimbal lock)
-        # For now, we don't update orientation_euler to avoid gimbal lock issues
-        # The authoritative source is the rotation matrix itself
+        # Extract Euler angles from the updated matrix (stored in degrees)
+        phi_r, theta_r, psi_r = matrix_to_euler(self.sample_to_lab_matrix[:3, :3].numpy())
+        self.orientation_euler = torch.tensor(
+            [np.rad2deg(phi_r), np.rad2deg(theta_r), np.rad2deg(psi_r)], dtype=torch.float32
+        )
 
     def rotate_axis_angle(self, axis: np.ndarray, angle_deg: float) -> None:
         """
@@ -281,6 +283,12 @@ class Sample:
         rotation_old = self.sample_to_lab_matrix[:3, :3]
         self.sample_to_lab_matrix[:3, :3] = torch.matmul(R, rotation_old)
 
+        # Extract Euler angles from the updated matrix (stored in degrees)
+        phi_r, theta_r, psi_r = matrix_to_euler(self.sample_to_lab_matrix[:3, :3].numpy())
+        self.orientation_euler = torch.tensor(
+            [np.rad2deg(phi_r), np.rad2deg(theta_r), np.rad2deg(psi_r)], dtype=torch.float32
+        )
+
     def rotate_z(self, omega: float) -> None:
         """
         Apply ACTIVE rotation around Z-axis (optimized version).
@@ -293,6 +301,10 @@ class Sample:
         C++ comment: "A ACTIVE rotation is used to go from the sample back to the lab."
 
         The operation is: oSampleToLabMatrix = Rz(omega) @ oSampleToLabMatrix
+
+        Note: This method does NOT update orientation_euler. It is called in the
+        innermost loop of cost function evaluation where callers save/restore the
+        full matrix. Extracting Euler angles here would be a performance regression.
 
         Args:
             omega: Rotation angle around Z-axis in RADIANS
@@ -338,8 +350,11 @@ class Sample:
 
         C++ Reference: Sample.h:97 (GetOrientation)
 
+        Note: C++ returns radians, but Python returns degrees to match
+        set_orientation() which takes degrees.
+
         Returns:
-            Euler angles [phi, theta, psi] in radians
+            Euler angles [phi, theta, psi] in degrees
         """
         return self.orientation_euler.numpy()
 
@@ -505,7 +520,7 @@ class Sample:
         return (
             f"Sample(\n"
             f"  location={location},\n"
-            f"  orientation_euler={orientation} rad,\n"
+            f"  orientation_euler={orientation} deg,\n"
             f"  num_voxels={num_voxels},\n"
             f"  num_phases={num_phases}\n"
             f")"

--- a/icenine_py/tests/test_sample.py
+++ b/icenine_py/tests/test_sample.py
@@ -361,15 +361,12 @@ class TestSampleTransformationsAdvanced:
         """Test Euler angle extraction after setting orientation."""
         sample = Sample()
 
-        # Set specific Euler angles
+        # Set specific Euler angles (degrees)
         phi, theta, psi = 45.0, 30.0, 60.0
         sample.set_orientation(phi, theta, psi)
 
-        # Get orientation back
+        # Get orientation back (now returns degrees, matching set_orientation)
         retrieved = sample.get_orientation()
-
-        # Convert back to degrees
-        retrieved_deg = np.rad2deg(retrieved)
 
         # Should match (within numerical precision)
         # Note: Euler angles may have multiple representations
@@ -378,9 +375,9 @@ class TestSampleTransformationsAdvanced:
 
         sample2 = Sample()
         sample2.set_orientation(
-            retrieved_deg[0],
-            retrieved_deg[1],
-            retrieved_deg[2]
+            retrieved[0],
+            retrieved[1],
+            retrieved[2]
         )
         R_retrieved = sample2.get_orientation_matrix()
 


### PR DESCRIPTION
## Summary

- **Sample orientation degree/radian mismatch** (`sample.py`): `get_orientation()` returned radians but `set_orientation()` expects degrees — round-trip `set_orientation(*get_orientation())` silently produced wrong results for non-zero orientations. `rotate()` and `rotate_axis_angle()` now update `orientation_euler` after matrix composition.
- **OverlapInfo.confidence semantic mismatch** (`cost_functions.py`): `confidence` property returned `quality` (Welford mean) instead of `peak_overlap / peak_on_detector` (C++ `GetConfidence`). Fixed to match C++.
- **Outdated "Remaining Work"** (`MIGRATION_HISTORY.md`): Listed reconstruction as "Not Yet Ported" despite being fully ported. Updated.
- **`_read_step_size_file` warning** (`experiment_setup.py`): Changed `print()` to `warnings.warn()`.
- **Crystal symmetry TODO** (`experiment_setup.py`): Replaced bare TODO with documented deferral rationale.

## Test plan

- [x] `uv run pytest tests/ -v` — 333 passed, 34 skipped (unchanged count)
- [x] `test_sample.py` Euler angle roundtrip test now works without manual `rad2deg` workaround
- [x] `test_cost_functions.py` all 17 tests pass with new `confidence` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)